### PR TITLE
feat: ignore MappedSuperclass entities

### DIFF
--- a/src/Anonymization/Config/Loader/AttributesLoader.php
+++ b/src/Anonymization/Config/Loader/AttributesLoader.php
@@ -31,6 +31,10 @@ class AttributesLoader implements LoaderInterface
 
         foreach ($metadatas as $metadata) {
             \assert($metadata instanceof ClassMetadata);
+            if ($metadata->isMappedSuperclass) {
+                continue;
+            }
+
             $reflexionClass = $metadata->getReflectionClass();
             if ($attributes = $reflexionClass->getAttributes(Anonymize::class)) {
                 foreach ($attributes as $key => $attribute) {


### PR DESCRIPTION
This kind of entity is used to be extended by others, so they must be ignored otherwise anonymizations try to be carried out on them which does not work.

For example:

* MappedSuperclass Person
* Entity Employee extends Person
* Entity Correspondant extends Person

The anonymization try to process thre tables: person, employee and correspondant whereas only two exists: employee and correspondant