### PR TITLE
fix: wrong condition on cancel confirmation

### DIFF
--- a/src/Command/Anonymization/AnonymizeCommand.php
+++ b/src/Command/Anonymization/AnonymizeCommand.php
@@ -184,7 +184,7 @@ class AnonymizeCommand extends Command
         }
 
         if (!$this->doBackupAndRestoreInitial) {
-            $this->doCancel = $this->io->confirm("You are about to erase your local database. Are you sure you want to continue?", true);
+            $this->doCancel = !$this->io->confirm("You are about to erase your local database. Are you sure you want to continue?", true);
         }
     }
 


### PR DESCRIPTION
The question `You are about to erase your local database. Are you sure you want to continue?` wants us to answer `yes` in order to continue; however the condition is not inverted so we must answer `no` to continue.