### PR TITLE
no issue - anonymizer join id index wasn't being created

### DIFF
--- a/src/Anonymization/Anonymizer/AbstractAnonymizer.php
+++ b/src/Anonymization/Anonymizer/AbstractAnonymizer.php
@@ -18,6 +18,7 @@ use MakinaCorpus\QueryBuilder\Query\Update;
 abstract class AbstractAnonymizer
 {
     public const JOIN_ID = '_db_tools_id';
+    public const JOIN_ID_INDEX = 'target_table_db_tools_id_idx';
     public const JOIN_TABLE = '_target_table';
     public const TEMP_TABLE_PREFIX = '_db_tools_sample_';
 

--- a/src/DependencyInjection/DbToolsExtension.php
+++ b/src/DependencyInjection/DbToolsExtension.php
@@ -66,7 +66,7 @@ final class DbToolsExtension extends Extension
             if ($strategyId !== null && $strategyId !== 'default' && $strategyId !== 'datetime') {
                 if ($container->hasDefinition($strategyId)) {
                     $strategies[$connectioName] = new Reference($strategyId);
-                } else if (\class_exists($strategyId)) {
+                } elseif (\class_exists($strategyId)) {
                     if (!\is_subclass_of($strategyId, FilenameStrategyInterface::class)) {
                         throw new InvalidArgumentException(\sprintf('"db_tools.connections.%s.filename_strategy": class "%s" does not implement "%s"', $connectioName, $strategyId, FilenameStrategyInterface::class));
                     }


### PR DESCRIPTION
Now we have the current figures in benchmark-app when this index is created:

 - sqlite: 0m2,981s
 - postgresql: 0m3,379s
 - mysql: 0m53,616s
 - mariadb: 0m9,582s

Previously, MariaDB and MySQL ran for hours, and we never completed any run.

Basically, EXPLAIN gave us the following information (10k rows in test table):

```
MariaDB [db]> analyze update `customer` inner join `customer` as `_target_table` on (`customer`.`_db_tools_id` = `_target_table`.`_db_tools_id`) left outer join (select `street_address`, `postal_code`, `locality`, `country`, ROW_NUMBER() OVER (ORDER BY rand()) as `rownum` from `_db_tools_sample_65cc870788a2d` limit 10000) as `_db_tools_sample_65cc870788a2d_address_0` on (CAST(`_target_table`.`_db_tools_id` AS SIGNED) % 302 + 1 = `_db_tools_sample_65cc870788a2d_address_0`.`rownum`) left outer join (select `value`, ROW_NUMBER() OVER (ORDER BY rand()) as `rownum` from `_db_tools_sample_65cc8707a63ce` limit 10000) as `_db_tools_sample_65cc8707a63ce_lastname` on (CAST(`_target_table`.`_db_tools_id` AS SIGNED) % 1000 + 1 = `_db_tools_sample_65cc8707a63ce_lastname`.`rownum` and `_target_table`.`lastname` is not null) left outer join (select `value`, ROW_NUMBER() OVER (ORDER BY rand()) as `rownum` from `_db_tools_sample_65cc8707d1382` limit 10000) as `_db_tools_sample_65cc8707d1382_firstname` on (CAST(`_target_table`.`_db_tools_id` AS SIGNED) % 1000 + 1 = `_db_tools_sample_65cc8707d1382_firstname`.`rownum` and `_target_table`.`firstname` is not null) left outer join (select `value`, ROW_NUMBER() OVER (ORDER BY rand()) as `rownum` from `_db_tools_sample_65cc870808f3f` limit 10000) as `_db_tools_sample_65cc870808f3f_level` on (CAST(`_target_table`.`_db_tools_id` AS SIGNED) % 4 + 1 = `_db_tools_sample_65cc870808f3f_level`.`rownum` and `_target_table`.`level` is not null) set `customer`.`street` = `_db_tools_sample_65cc870788a2d_address_0`.`street_address`, `customer`.`zip_code` = `_db_tools_sample_65cc870788a2d_address_0`.`postal_code`, `customer`.`city` = `_db_tools_sample_65cc870788a2d_address_0`.`locality`, `customer`.`country` = `_db_tools_sample_65cc870788a2d_address_0`.`country`, `customer`.`email` = case   when `customer`.`email` is not null then CONCAT('anon-', md5(CAST(`customer`.`email` AS CHAR)), '@', 'example.com') else null end, `customer`.`password` = case   when `customer`.`password` is not null then '$2y$13$JdPOxZxyVW5qXTaZB4VL6.l6I4roaFMT7NdU8vVFNN6GfW9mL3kLa' else null end, `customer`.`lastname` = `_db_tools_sample_65cc8707a63ce_lastname`.`value`, `customer`.`firstname` = `_db_tools_sample_65cc8707d1382_firstname`.`value`, `customer`.`level` = `_db_tools_sample_65cc870808f3f_level`.`value`, `customer`.`age` = case   when `customer`.`age` is not null then FLOOR(rand() * (CAST(99 AS SIGNED) - 10 + 1) + 10) else null end;
+------+-------------+--------------------------------+------+---------------+------+---------+------+------+----------+----------+------------+-----------------+
| id   | select_type | table                          | type | possible_keys | key  | key_len | ref  | rows | r_rows   | filtered | r_filtered | Extra           |
+------+-------------+--------------------------------+------+---------------+------+---------+------+------+----------+----------+------------+-----------------+
|    1 | PRIMARY     | customer                       | ALL  | NULL          | NULL | NULL    | NULL | 9891 | 10000.00 |   100.00 |     100.00 |                 |
|    1 | PRIMARY     | _target_table                  | ALL  | NULL          | NULL | NULL    | NULL | 9891 | 10000.00 |   100.00 |       0.01 | Using where     |
|    1 | PRIMARY     | <derived2>                     | ref  | key0          | key0 | 8       | func | 10   | 1.00     |   100.00 |     100.00 | Using where     |
|    1 | PRIMARY     | <derived3>                     | ref  | key0          | key0 | 8       | func | 10   | 1.00     |   100.00 |     100.00 | Using where     |
|    1 | PRIMARY     | <derived4>                     | ref  | key0          | key0 | 8       | func | 10   | 1.00     |   100.00 |     100.00 | Using where     |
|    1 | PRIMARY     | <derived5>                     | ref  | key0          | key0 | 8       | func | 1    | 1.00     |   100.00 |     100.00 | Using where     |
|    5 | DERIVED     | _db_tools_sample_65cc870808f3f | ALL  | NULL          | NULL | NULL    | NULL | 4    | 4.00     |   100.00 |     100.00 | Using temporary |
|    4 | DERIVED     | _db_tools_sample_65cc8707d1382 | ALL  | NULL          | NULL | NULL    | NULL | 1000 | 1000.00  |   100.00 |     100.00 | Using temporary |
|    3 | DERIVED     | _db_tools_sample_65cc8707a63ce | ALL  | NULL          | NULL | NULL    | NULL | 1000 | 1000.00  |   100.00 |     100.00 | Using temporary |
|    2 | DERIVED     | _db_tools_sample_65cc870788a2d | ALL  | NULL          | NULL | NULL    | NULL | 302  | 302.00   |   100.00 |     100.00 | Using temporary |
+------+-------------+--------------------------------+------+---------------+------+---------+------+------+----------+----------+------------+-----------------+
```

And now with the index:

```
MariaDB [db]> explain update `customer` inner join `customer` as `_target_table` on (`customer`.`_db_tools_id` = `_target_table`.`_db_tools_id`) left outer join (select `street_address`, `postal_code`, `locality`, `country`, ROW_NUMBER() OVER (ORDER BY rand()) as `rownum` from `_db_tools_sample_65cc870788a2d` limit 10000) as `_db_tools_sample_65cc870788a2d_address_0` on (CAST(`_target_table`.`_db_tools_id` AS SIGNED) % 302 + 1 = `_db_tools_sample_65cc870788a2d_address_0`.`rownum`) left outer join (select `value`, ROW_NUMBER() OVER (ORDER BY rand()) as `rownum` from `_db_tools_sample_65cc8707a63ce` limit 10000) as `_db_tools_sample_65cc8707a63ce_lastname` on (CAST(`_target_table`.`_db_tools_id` AS SIGNED) % 1000 + 1 = `_db_tools_sample_65cc8707a63ce_lastname`.`rownum` and `_target_table`.`lastname` is not null) left outer join (select `value`, ROW_NUMBER() OVER (ORDER BY rand()) as `rownum` from `_db_tools_sample_65cc8707d1382` limit 10000) as `_db_tools_sample_65cc8707d1382_firstname` on (CAST(`_target_table`.`_db_tools_id` AS SIGNED) % 1000 + 1 = `_db_tools_sample_65cc8707d1382_firstname`.`rownum` and `_target_table`.`firstname` is not null) left outer join (select `value`, ROW_NUMBER() OVER (ORDER BY rand()) as `rownum` from `_db_tools_sample_65cc870808f3f` limit 10000) as `_db_tools_sample_65cc870808f3f_level` on (CAST(`_target_table`.`_db_tools_id` AS SIGNED) % 4 + 1 = `_db_tools_sample_65cc870808f3f_level`.`rownum` and `_target_table`.`level` is not null) set `customer`.`street` = `_db_tools_sample_65cc870788a2d_address_0`.`street_address`, `customer`.`zip_code` = `_db_tools_sample_65cc870788a2d_address_0`.`postal_code`, `customer`.`city` = `_db_tools_sample_65cc870788a2d_address_0`.`locality`, `customer`.`country` = `_db_tools_sample_65cc870788a2d_address_0`.`country`, `customer`.`email`
= case   when `customer`.`email` is not null then CONCAT('anon-', md5(CAST(`customer`.`email` AS CHAR)), '@', 'example.com') else null end, `customer`.`password` = case   when `customer`.`password` is not null then '$2y$13$JdPOxZxyVW5qXTaZB4VL6.l6I4roaFMT7NdU8vVFNN6GfW9mL3kLa' else null end, `customer`.`lastname` = `_db_tools_sample_65cc8707a63ce_lastname`.`value`, `customer`.`firstname` = `_db_tools_sample_65cc8707d1382_firstname`.`value`, `customer`.`level` = `_db_tools_sample_65cc870808f3f_level`.`value`, `customer`.`age` = case   when `customer`.`age` is not null then FLOOR(rand() * (CAST(99 AS SIGNED) - 10 + 1) + 10) else null end;
+------+-------------+--------------------------------+------+---------------------------+---------------------------+---------+--------------------------+------+-----------------+
| id   | select_type | table                          | type | possible_keys             | key                       | key_len | ref                      | rows | Extra           |
+------+-------------+--------------------------------+------+---------------------------+---------------------------+---------+--------------------------+------+-----------------+
|    1 | PRIMARY     | customer                       | ALL  | customer__db_tools_id_idx | NULL                      | NULL    | NULL                     | 9891 | Using where     |
|    1 | PRIMARY     | _target_table                  | ref  | customer__db_tools_id_idx | customer__db_tools_id_idx | 9       | db.customer._db_tools_id | 1    |                 |
|    1 | PRIMARY     | <derived2>                     | ref  | key0                      | key0                      | 8       | func                     | 10   | Using where     |
|    1 | PRIMARY     | <derived3>                     | ref  | key0                      | key0                      | 8       | func                     | 10   | Using where     |
|    1 | PRIMARY     | <derived4>                     | ref  | key0                      | key0                      | 8       | func                     | 10   | Using where     |
|    1 | PRIMARY     | <derived5>                     | ref  | key0                      | key0                      | 8       | func                     | 1    | Using where     |
|    5 | DERIVED     | _db_tools_sample_65cc870808f3f | ALL  | NULL                      | NULL                      | NULL    | NULL                     | 4    | Using temporary |
|    4 | DERIVED     | _db_tools_sample_65cc8707d1382 | ALL  | NULL                      | NULL                      | NULL    | NULL                     | 1000 | Using temporary |
|    3 | DERIVED     | _db_tools_sample_65cc8707a63ce | ALL  | NULL                      | NULL                      | NULL    | NULL                     | 1000 | Using temporary |
|    2 | DERIVED     | _db_tools_sample_65cc870788a2d | ALL  | NULL                      | NULL                      | NULL    | NULL                     | 302  | Using temporary |
+------+-------------+--------------------------------+------+---------------------------+---------------------------+---------+--------------------------+------+-----------------+
```

Note that in the first one, first join is `ALL`, which means it actually does a full scan of the table multiplied by a full scan of the table, which is exponential complexity.

Now, the first join uses the index, and the full scan drops to linear complexity (it anonymizes all rows of the table, as expected).

All of this only because of a forgotten `->executeStatement()` call :scream:.