### PR TITLE
Issue #79 - Complete or replace default options

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -30,7 +30,6 @@ services:
         arguments:
             - '%doctrine.default_connection%'
             - '%db_tools.excluded_tables%'
-            - '%db_tools.backupper.options%'
             - '@db_tools.backupper.factory'
             - '@db_tools.storage'
         tags: ['console.command']
@@ -45,7 +44,6 @@ services:
         class: MakinaCorpus\DbToolsBundle\Command\RestoreCommand
         arguments:
             - '%doctrine.default_connection%'
-            - '%db_tools.restorer.options%'
             - '@db_tools.restorer.factory'
             - '@db_tools.storage'
         tags: ['console.command']
@@ -64,12 +62,12 @@ services:
     # Backuppers
     db_tools.backupper.factory:
         class: MakinaCorpus\DbToolsBundle\Backupper\BackupperFactory
-        arguments: ['@doctrine', '%db_tools.backupper.binaries%']
+        arguments: ['@doctrine', '%db_tools.backupper.binaries%', '%db_tools.backupper.options%']
 
     # Restorers
     db_tools.restorer.factory:
         class: MakinaCorpus\DbToolsBundle\Restorer\RestorerFactory
-        arguments: ['@doctrine', '%db_tools.restorer.binaries%']
+        arguments: ['@doctrine', '%db_tools.restorer.binaries%', '%db_tools.restorer.options%']
 
     # Stats providers
     db_tools.stats_provider.factory:

--- a/docs/content/backup_restore.md
+++ b/docs/content/backup_restore.md
@@ -60,32 +60,25 @@ Note that using this option, backup files will never be cleaned up.
 
 ### Extra options
 
-If you temporarily want to provide your own options to the backup binary,
-use the `--extra-options` (`-o`) in your command:
+If you need to occasionally provide some custom options to the backup binary,
+use the `--extra-options` (`-o`) option in your command:
 
 ```sh
 console db-tools:backup --extra-options "--opt1 val1 --opt2 val2 --flag"
 ```
 
-If you always need to use the same custom options when backing up, you can
-define them as default options in the bundle configuration file:
+Unless you specify the `--ignore-default-options` option, the custom options
+will be added to the [default options](./configuration#default-binary-options).
 
-```yaml
-# config/packages/db_tools.yaml
-db_tools:
-    # ...
-    backupper_options:
-        my_doctrine_connection: "--opt1 val1 --opt2 val2 --flag"
+### Ignoring default options
+
+If necessary, [default options](./configuration#default-binary-options) can be
+ignored for a backup by using the `--ignore-default-options` option:
+
+```sh
+# Will run a backup without any special options except essential ones:
+console db-tools:backup --ignore-default-options
 ```
-
-See the section about the [bundle configuration](./configuration#default-binary-options)
-for more information.
-
-:::warning
-The `--extra-options` option overrides default options defined in the
-configuration file as well as those from the bundle itself. (No merge
-will be performed.)
-:::
 
 ## Restore command
 
@@ -142,32 +135,25 @@ really want to do so.
 
 ### Extra options
 
-If you temporarily want to provide your own options to the restoration binary,
-use the `--extra-options` (`-o`) in your command:
+If you need to occasionally provide some custom options to the restoration
+binary, use the `--extra-options` (`-o`) option in your command:
 
 ```sh
 console db-tools:restore --extra-options "--opt1 val1 --opt2 val2 --flag"
 ```
 
-If you always need to use the same custom options when restoring, you can define
-them as default options in the bundle configuration file:
+Unless you specify the `--ignore-default-options` option, the custom options
+will be added to the [default options](./configuration#default-binary-options).
 
-```yaml
-# config/packages/db_tools.yaml
-db_tools:
-    # ...
-    restorer_options:
-        my_doctrine_connection: "--opt1 val1 --opt2 val2 --flag"
+### Ignoring default options
+
+If necessary, [default options](./configuration#default-binary-options) can be 
+ignored for a restoration by using the `--ignore-default-options` option:
+
+```sh
+# Will run a restoration without any special options except essential ones:
+console db-tools:restore --ignore-default-options
 ```
-
-See the section about the [bundle configuration](./configuration#default-binary-options)
-for more information.
-
-:::warning
-The `--extra-options` option overrides default options defined in the
-configuration file as well as those from the bundle itself. (No merge
-will be performed.)
-:::
 
 ## Storage
 

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -113,7 +113,7 @@ Note that you can override this configuration while running the `db-tools:backup
 the `--exclude` option.
 :::
 
-### Extra options
+### Binary options
 
 See the [default binary options](#default-binary-options) section.
 

--- a/src/Backupper/AbstractBackupper.php
+++ b/src/Backupper/AbstractBackupper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MakinaCorpus\DbToolsBundle\Backupper;
 
 use Doctrine\DBAL\Connection;
+use MakinaCorpus\DbToolsBundle\Utility\CommandLine;
 use Symfony\Component\Process\Process;
 
 /**
@@ -14,15 +15,23 @@ use Symfony\Component\Process\Process;
  */
 abstract class AbstractBackupper implements \IteratorAggregate
 {
+    /** @var string */
+    public const DEFAULT_OPTIONS = '';
+
     protected ?string $destination = null;
     protected array $excludedTables = [];
+    protected string $defaultOptions = '';
     protected ?string $extraOptions = null;
+    protected bool $ignoreDefaultOptions = false;
     protected bool $verbose = false;
 
     public function __construct(
         protected string $binary,
         protected Connection $connection,
+        ?string $defaultOptions = null,
     ) {
+        $this->defaultOptions = $defaultOptions ?? static::DEFAULT_OPTIONS;
+
         $this->destination = \sprintf(
             '%s/db-tools-backup-%s.dump',
             \sys_get_temp_dir(),
@@ -84,6 +93,18 @@ abstract class AbstractBackupper implements \IteratorAggregate
         return $this->extraOptions;
     }
 
+    public function ignoreDefaultOptions(bool $switch = true): self
+    {
+        $this->ignoreDefaultOptions = $switch;
+
+        return $this;
+    }
+
+    public function areDefaultOptionsIgnored(): bool
+    {
+        return $this->ignoreDefaultOptions;
+    }
+
     public function setVerbose(bool $verbose): self
     {
         $this->verbose = $verbose;
@@ -94,6 +115,16 @@ abstract class AbstractBackupper implements \IteratorAggregate
     public function isVerbose(): bool
     {
         return $this->verbose;
+    }
+
+    protected function addCustomOptions(CommandLine $command): void
+    {
+        if (!$this->ignoreDefaultOptions) {
+            $command->addRaw($this->defaultOptions);
+        }
+        if ($this->extraOptions) {
+            $command->addRaw($this->extraOptions);
+        }
     }
 
     abstract public function startBackup(): self;

--- a/src/Backupper/BackupperFactory.php
+++ b/src/Backupper/BackupperFactory.php
@@ -12,9 +12,16 @@ use MakinaCorpus\QueryBuilder\Platform;
 
 class BackupperFactory
 {
+    /**
+     * Constructor.
+     *
+     * @param array<string, string> $backupperBinaries
+     * @param array<string, string> $backupperOptions
+     */
     public function __construct(
         private ManagerRegistry $doctrineRegistry,
         private array $backupperBinaries,
+        private array $backupperOptions = [],
     ) {}
 
     /**
@@ -43,7 +50,8 @@ class BackupperFactory
 
         return new $backupper(
             $this->backupperBinaries[$platform],
-            $connection
+            $connection,
+            $this->backupperOptions[$connectionName] ?? null
         );
     }
 }

--- a/src/Backupper/MariaDB/Backupper.php
+++ b/src/Backupper/MariaDB/Backupper.php
@@ -11,6 +11,8 @@ use Symfony\Component\Process\Process;
 
 class Backupper extends AbstractBackupper
 {
+    public const DEFAULT_OPTIONS = '--no-tablespaces';
+
     private ?Process $process = null;
 
     /**
@@ -41,11 +43,9 @@ class Backupper extends AbstractBackupper
         if ($this->verbose) {
             $command->addArg('-v');
         }
-        if ($this->extraOptions) {
-            $command->addRaw($this->extraOptions);
-        } else {
-            $command->addArg('--no-tablespaces');
-        }
+
+        $this->addCustomOptions($command);
+
         if ($this->destination) {
             $command->addArg('-r', $this->destination);
         }

--- a/src/Backupper/MySQL/Backupper.php
+++ b/src/Backupper/MySQL/Backupper.php
@@ -11,6 +11,8 @@ use Symfony\Component\Process\Process;
 
 class Backupper extends AbstractBackupper
 {
+    public const DEFAULT_OPTIONS = '--no-tablespaces';
+
     private ?Process $process = null;
 
     /**
@@ -41,11 +43,7 @@ class Backupper extends AbstractBackupper
         if ($this->verbose) {
             $command->addArg('-v');
         }
-        if ($this->extraOptions) {
-            $command->addRaw($this->extraOptions);
-        } else {
-            $command->addArg('--no-tablespaces');
-        }
+        $this->addCustomOptions($command);
         if ($this->destination) {
             $command->addArg('-r', $this->destination);
         }

--- a/src/Backupper/PgSQL/Backupper.php
+++ b/src/Backupper/PgSQL/Backupper.php
@@ -11,6 +11,9 @@ use Symfony\Component\Process\Process;
 
 class Backupper extends AbstractBackupper
 {
+    // Compression level (0-9)
+    public const DEFAULT_OPTIONS = "-Z 5 --lock-wait-timeout=120";
+
     private ?Process $process = null;
 
     /**
@@ -39,16 +42,10 @@ class Backupper extends AbstractBackupper
         if ($this->verbose) {
             $command->addArg('-v');
         }
-        if ($this->extraOptions) {
-            $command->addRaw($this->extraOptions);
-        } else {
-            // Compression level (0-9)
-            $command->addArg('-Z', '5');
-            $command->addArg('--lock-wait-timeout=120');
-        }
 
-        // Custom format (not SQL)
-        // Not overridable for now.
+        $this->addCustomOptions($command);
+        // Custom format (not SQL).
+        // Forced for now.
         $command->addArg('-F', 'c');
 
         if ($this->destination) {

--- a/src/Backupper/SQLite/Backupper.php
+++ b/src/Backupper/SQLite/Backupper.php
@@ -13,6 +13,8 @@ use Symfony\Component\Process\Process;
 
 class Backupper extends AbstractBackupper
 {
+    public const DEFAULT_OPTIONS = '-bail';
+
     private ?Process $process = null;
 
     /**
@@ -23,17 +25,17 @@ class Backupper extends AbstractBackupper
         $dbParams = $this->connection->getParams();
         $tablesToBackup = \implode(' ', $this->getTablesToBackup());
 
-        $command = new CommandLine(
-            \sprintf(
-                "echo 'BEGIN IMMEDIATE;\n.dump %s' | %s %s %s  > \"%s\"",
-                $tablesToBackup,
-                $this->binary,
-                $this->extraOptions ?: '-bail',
-                $dbParams['path'],
-                \addcslashes($this->destination, '\\"')
-            ),
-            false
-        );
+        // The CommandLine instance below will generate something like:
+        // echo 'BEGIN IMMEDIATE;\n.dump table1 table2 ...' | 'sqlite3' -bail > '/path/to/backup.sql'
+        $command = new CommandLine();
+        $command->addRaw(\sprintf(
+            "echo 'BEGIN IMMEDIATE;\n.dump %s' |", $tablesToBackup
+        ));
+        $command->addArg($this->binary);
+        $this->addCustomOptions($command);
+        $command->addArg($dbParams['path']);
+        $command->addRaw('>');
+        $command->addArg($this->destination);
 
         $this->process = Process::fromShellCommandline($command->toString());
         $this->process->setTimeout(600);

--- a/src/Restorer/AbstractRestorer.php
+++ b/src/Restorer/AbstractRestorer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MakinaCorpus\DbToolsBundle\Restorer;
 
 use Doctrine\DBAL\Connection;
+use MakinaCorpus\DbToolsBundle\Utility\CommandLine;
 use Symfony\Component\Process\Process;
 
 /**
@@ -12,17 +13,24 @@ use Symfony\Component\Process\Process;
  */
 abstract class AbstractRestorer implements \IteratorAggregate
 {
+    public const DEFAULT_OPTIONS = '';
+
     protected ?string $backupFilename = null;
+    protected string $defaultOptions = '';
     protected ?string $extraOptions = null;
+    protected bool $ignoreDefaultOptions = false;
     protected bool $verbose = false;
 
     public function __construct(
         protected string $binary,
         protected Connection $connection,
-    ) {}
+        ?string $defaultOptions = null,
+    ) {
+        $this->defaultOptions = $defaultOptions ?? static::DEFAULT_OPTIONS;
+    }
 
     /**
-     * Check that restore utility can be execute correctly.
+     * Check that restore utility can be executed correctly.
      */
     public function checkBinary(): string
     {
@@ -63,6 +71,18 @@ abstract class AbstractRestorer implements \IteratorAggregate
         return $this->extraOptions;
     }
 
+    public function ignoreDefaultOptions(bool $switch = true): self
+    {
+        $this->ignoreDefaultOptions = $switch;
+
+        return $this;
+    }
+
+    public function areDefaultOptionsIgnored(): bool
+    {
+        return $this->ignoreDefaultOptions;
+    }
+
     public function setVerbose(bool $verbose): self
     {
         $this->verbose = $verbose;
@@ -73,6 +93,16 @@ abstract class AbstractRestorer implements \IteratorAggregate
     public function isVerbose(): bool
     {
         return $this->verbose;
+    }
+
+    protected function addCustomOptions(CommandLine $command): void
+    {
+        if (!$this->ignoreDefaultOptions) {
+            $command->addRaw($this->defaultOptions);
+        }
+        if ($this->extraOptions) {
+            $command->addRaw($this->extraOptions);
+        }
     }
 
     abstract public function startRestore(): self;

--- a/src/Restorer/MariaDB/Restorer.php
+++ b/src/Restorer/MariaDB/Restorer.php
@@ -13,6 +13,7 @@ class Restorer extends AbstractRestorer
 {
     private ?Process $process = null;
     private mixed $backupStream = null;
+
     /**
      * {@inheritdoc}
      */
@@ -36,10 +37,8 @@ class Restorer extends AbstractRestorer
         if ($this->verbose) {
             $command->addArg('-v');
         }
-        if ($this->extraOptions) {
-            $command->addRaw($this->extraOptions);
-        }
 
+        $this->addCustomOptions($command);
         $command->addArg($dbParams['dbname']);
 
         $this->backupStream = \fopen($this->backupFilename, 'r');

--- a/src/Restorer/MySQL/Restorer.php
+++ b/src/Restorer/MySQL/Restorer.php
@@ -37,10 +37,8 @@ class Restorer extends AbstractRestorer
         if ($this->verbose) {
             $command->addArg('-v');
         }
-        if ($this->extraOptions) {
-            $command->addRaw($this->extraOptions);
-        }
 
+        $this->addCustomOptions($command);
         $command->addArg($dbParams['dbname']);
 
         $this->backupStream = \fopen($this->backupFilename, 'r');

--- a/src/Restorer/PgSQL/Restorer.php
+++ b/src/Restorer/PgSQL/Restorer.php
@@ -11,6 +11,8 @@ use Symfony\Component\Process\Process;
 
 class Restorer extends AbstractRestorer
 {
+    public const DEFAULT_OPTIONS = '-j 2 --clean --if-exists --disable-triggers';
+
     private ?Process $process = null;
 
     /**
@@ -36,15 +38,8 @@ class Restorer extends AbstractRestorer
         if ($this->verbose) {
             $command->addArg('-v');
         }
-        if ($this->extraOptions) {
-            $command->addRaw($this->extraOptions);
-        } else {
-            $command->addArg('--clean');
-            $command->addArg('-j', '2');
-            $command->addArg('--if-exists');
-            $command->addArg('--disable-triggers');
-        }
 
+        $this->addCustomOptions($command);
         $command->addArg('-d', $dbParams['dbname']);
         $command->addArg($this->backupFilename);
 

--- a/src/Restorer/RestorerFactory.php
+++ b/src/Restorer/RestorerFactory.php
@@ -12,9 +12,16 @@ use MakinaCorpus\QueryBuilder\Platform;
 
 class RestorerFactory
 {
+    /**
+     * Constructor.
+     *
+     * @param array<string, string> $restorerBinaries
+     * @param array<string, string> $restorerOptions
+     */
     public function __construct(
         private ManagerRegistry $doctrineRegistry,
         private array $restorerBinaries,
+        private array $restorerOptions = [],
     ) {}
 
     /**
@@ -43,7 +50,8 @@ class RestorerFactory
 
         return new $restorer(
             $this->restorerBinaries[$platform],
-            $connection
+            $connection,
+            $this->restorerOptions[$connectionName] ?? null
         );
     }
 }

--- a/src/Restorer/SQLite/Restorer.php
+++ b/src/Restorer/SQLite/Restorer.php
@@ -23,20 +23,14 @@ class Restorer extends AbstractRestorer
         }
 
         $dbParams = $this->connection->getParams();
-
         // Remove existing database to restore file in an empty one.
         \unlink($dbParams['path']);
 
-        $command = new CommandLine(
-            \sprintf(
-                '%s %s%s < "%s"',
-                $this->binary,
-                $this->extraOptions ? $this->extraOptions . ' ' : '',
-                $dbParams['path'],
-                \addcslashes($this->backupFilename, '\\"')
-            ),
-            false
-        );
+        $command = new CommandLine($this->binary);
+        $this->addCustomOptions($command);
+        $command->addArg($dbParams['path']);
+        $command->addRaw('<');
+        $command->addArg($this->backupFilename);
 
         $this->process = Process::fromShellCommandline($command->toString());
         $this->process->setTimeout(1800);

--- a/src/Utility/CommandLine.php
+++ b/src/Utility/CommandLine.php
@@ -50,7 +50,9 @@ class CommandLine
      */
     public function addRaw(string $raw): self
     {
-        $this->args[] = $raw;
+        if ($raw) {
+            $this->args[] = $raw;
+        }
 
         return $this;
     }
@@ -58,6 +60,7 @@ class CommandLine
     public function toString(): string
     {
         $command = \implode(' ', $this->args);
+
         if (!$this->osIsWindows()) {
             // exec is mandatory to deal with sending a signal to the process.
             $command = 'exec ' . $command;
@@ -74,8 +77,9 @@ class CommandLine
     /**
      * Escape a string to be used as a shell argument.
      *
-     * The code below has been copied from the Symfony Process component
-     * released under the MIT licence with the following copyright:
+     * The code below has been copied (and slightly modified) from the
+     * Symfony Process component released under the MIT licence with the
+     * following copyright:
      *
      * @copyright Copyright (c) 2004-present Fabien Potencier
      * @author Fabien Potencier <fabien@symfony.com>

--- a/tests/Functional/BackupperRestorer/BackupperRestorerTest.php
+++ b/tests/Functional/BackupperRestorer/BackupperRestorerTest.php
@@ -150,6 +150,7 @@ class BackupperRestorerTest extends FunctionalTestCase
                 $platform instanceof SqlitePlatform => '-bail -readonly', // No interesting options for SQLite.
                 default => $this->markTestSkipped('Driver unsupported: ' . \getenv('DBAL_DRIVER')),
             })
+            ->ignoreDefaultOptions()
             ->setVerbose(false) // Enable via an extra option.
             ->startBackup()
         ;
@@ -276,6 +277,7 @@ class BackupperRestorerTest extends FunctionalTestCase
                 $platform instanceof SqlitePlatform => '-bail', // No interesting options for SQLite.
                 default => $this->markTestSkipped('Driver unsupported: ' . \getenv('DBAL_DRIVER')),
             })
+            ->ignoreDefaultOptions()
             ->setVerbose(false) // Enable via an extra option.
             ->startRestore()
         ;

--- a/tests/Unit/Utility/CommandLineTest.php
+++ b/tests/Unit/Utility/CommandLineTest.php
@@ -46,7 +46,7 @@ class CommandLineTest extends TestCase
 
         $cl = new CommandLine(['test', 3, '-x', 42.24, '--opt=val', '-m', null], false);
         self::assertSame(
-            ['test', '3', '-x', '42.24', '--opt=val', '-m', ''],
+            ['test', '3', '-x', '42.24', '--opt=val', '-m'],
             $this->extractArgs($cl)
         );
     }


### PR DESCRIPTION
Add the `--replace-defaults` option to backup and restoration commands to control the behavior of the `--extra-options` option.