### PR TITLE
No issue - Fix constructor of the BackupperFactory class

### DIFF
--- a/src/Backupper/BackupperFactory.php
+++ b/src/Backupper/BackupperFactory.php
@@ -30,7 +30,7 @@ class BackupperFactory
         $connectionNames = $this->doctrineRegistry->getConnectionNames();
 
         foreach ($this->backupperOptions as $connectionName => $options) {
-            if (!\in_array($connectionName, $connectionNames, true)) {
+            if (!isset($connectionNames[$connectionName])) {
                 throw new \DomainException(\sprintf(
                     "'%s' is not a valid Doctrine connection name.",
                     $connectionName
@@ -44,7 +44,7 @@ class BackupperFactory
         }
 
         foreach ($this->excludedTables as $connectionName => $tableNames) {
-            if (!\in_array($connectionName, $connectionNames, true)) {
+            if (!isset($connectionNames[$connectionName])) {
                 throw new \DomainException(\sprintf(
                     "'%s' is not a valid Doctrine connection name.",
                     $connectionName

--- a/tests/Unit/Backupper/BackupperFactoryTest.php
+++ b/tests/Unit/Backupper/BackupperFactoryTest.php
@@ -84,7 +84,10 @@ class BackupperFactoryTest extends TestCase
         $doctrineRegistry
             ->expects($this->any())
             ->method('getConnectionNames')
-            ->willReturn(['default', 'another'])
+            ->willReturn([
+                'default' => 'doctrine.dbal.default_connection',
+                'another' => 'doctrine.dbal.another_connection',
+            ])
         ;
         $doctrineRegistry
             ->expects($this->any())


### PR DESCRIPTION
Because I forgot to check the content of the array returned by the `Doctrine\Persistence\ManagerRegistry::getConnectionNames()` method before merging my previous PR... :sweat_smile: