### PR TITLE
feat: remove deprecation warnings for Symfony 7 strong typing

### DIFF
--- a/src/Command/Anonymization/CleanCommand.php
+++ b/src/Command/Anonymization/CleanCommand.php
@@ -25,7 +25,7 @@ class CleanCommand extends Command
     }
 
     #[\Override]
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Clean DbTools left-over temporary tables, columns and indexes.')

--- a/src/Command/CheckCommand.php
+++ b/src/Command/CheckCommand.php
@@ -26,7 +26,7 @@ class CheckCommand extends Command
     }
 
     #[\Override]
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Check DbTools configuration')

--- a/src/Command/StatsCommand.php
+++ b/src/Command/StatsCommand.php
@@ -31,7 +31,7 @@ class StatsCommand extends Command
     }
 
     #[\Override]
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Give some database statistics')

--- a/src/DependencyInjection/DbToolsExtension.php
+++ b/src/DependencyInjection/DbToolsExtension.php
@@ -12,11 +12,12 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 final class DbToolsExtension extends Extension
 {
     #[\Override]
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
@@ -85,7 +86,7 @@ final class DbToolsExtension extends Extension
     }
 
     #[\Override]
-    public function getConfiguration(array $config, ContainerBuilder $container)
+    public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface
     {
         return new DbToolsConfiguration();
     }


### PR DESCRIPTION
Solve this warnings:

![image](https://github.com/makinacorpus/DbToolsBundle/assets/14254/608b29e5-878f-4c0f-b3d2-7ff3240f13cd)

![image](https://github.com/makinacorpus/DbToolsBundle/assets/14254/0c810bf2-b4cf-4f1b-b9fe-b2c2f97e5e77)
