### PR TITLE
various improvements to ./dev.sh

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -47,7 +47,7 @@ section_title() {
 
 # Run docker compose for project
 do_docker_compose() {
-    docker compose -p db_tools_bundle_test $@
+    docker compose -p db_tools_bundle_test "$@"
 }
 
 # Build docker containers
@@ -109,7 +109,7 @@ do_test_mysql57() {
         -e DBAL_ROOT_USER="root" \
         -e DBAL_USER=root \
         -e DATABASE_URL=mysql://root:password@mysql57:3306/test_db?serverVersion=5.7 \
-        $PHPUNIT_CONTAINER vendor/bin/phpunit $@
+        $PHPUNIT_CONTAINER vendor/bin/phpunit "$@"
 }
 
 do_test_mysql80() {
@@ -124,7 +124,7 @@ do_test_mysql80() {
         -e DBAL_ROOT_USER=root \
         -e DBAL_USER=root \
         -e DATABASE_URL=mysql://root:password@mysql80:3306/test_db?serverVersion=8 \
-        "$PHPUNIT_CONTAINER" vendor/bin/phpunit $@
+        "$PHPUNIT_CONTAINER" vendor/bin/phpunit "$@"
 }
 
 do_test_mysql83() {
@@ -139,7 +139,7 @@ do_test_mysql83() {
         -e DBAL_ROOT_USER=root \
         -e DBAL_USER=root \
         -e DATABASE_URL=mysql://root:password@mysql83:3306/test_db?serverVersion=8 \
-        $PHPUNIT_CONTAINER vendor/bin/phpunit $@
+        $PHPUNIT_CONTAINER vendor/bin/phpunit "$@"
 }
 
 do_test_mariadb11() {
@@ -154,16 +154,16 @@ do_test_mariadb11() {
         -e DBAL_ROOT_USER="root" \
         -e DBAL_USER=root \
         -e DATABASE_URL=mysql://root:password@mariadb11:3306/test_db?serverVersion=mariadb-11.1.3 \
-        $PHPUNIT_CONTAINER vendor/bin/phpunit $@
+        $PHPUNIT_CONTAINER vendor/bin/phpunit "$@"
 }
 
 do_test_mysql() {
     # @todo Temporary deactivated MySQL 5.7 due to a bug.
     # https://github.com/makinacorpus/DbToolsBundle/issues/124
     # do_test_mysql57
-    do_test_mysql80 $@
-    do_test_mysql83 $@
-    do_test_mariadb11 $@
+    do_test_mysql80 "$@"
+    do_test_mysql83 "$@"
+    do_test_mariadb11 "$@"
 }
 
 do_test_postgresql10() {
@@ -178,7 +178,7 @@ do_test_postgresql10() {
         -e DBAL_ROOT_USER=postgres \
         -e DBAL_USER=postgres \
         -e DATABASE_URL="postgresql://postgres:password@postgresql10:5432/test_db?serverVersion=10&charset=utf8" \
-        $PHPUNIT_CONTAINER vendor/bin/phpunit $@
+        $PHPUNIT_CONTAINER vendor/bin/phpunit "$@"
 }
 
 do_test_postgresql16() {
@@ -193,12 +193,12 @@ do_test_postgresql16() {
         -e DBAL_ROOT_USER=postgres \
         -e DBAL_USER=postgres \
         -e DATABASE_URL="postgresql://postgres:password@postgresql16:5432/test_db?serverVersion=16&charset=utf8" \
-        $PHPUNIT_CONTAINER vendor/bin/phpunit $@
+        $PHPUNIT_CONTAINER vendor/bin/phpunit "$@"
 }
 
 do_test_postgresql() {
-    do_test_postgresql10 $@
-    do_test_postgresql16 $@
+    do_test_postgresql10 "$@"
+    do_test_postgresql16 "$@"
 }
 
 do_test_sqlsrv2019() {
@@ -213,7 +213,7 @@ do_test_sqlsrv2019() {
         -e DBAL_ROOT_USER=sa \
         -e DBAL_USER=sa \
         -e DATABASE_URL="pdo-sqlsrv://sa:P%40ssword123@sqlsrv2019:1433/test_db?serverVersion=2019&charset=utf8&driverOptions[TrustServerCertificate]=true" \
-        $PHPUNIT_CONTAINER vendor/bin/phpunit $@
+        $PHPUNIT_CONTAINER vendor/bin/phpunit "$@"
 }
 
 do_test_sqlsrv2022() {
@@ -228,12 +228,12 @@ do_test_sqlsrv2022() {
         -e DBAL_ROOT_USER=sa \
         -e DBAL_USER=sa \
         -e DATABASE_URL="pdo-sqlsrv://sa:P%40ssword123@sqlsrv2022:1433/test_db?serverVersion=2022&charset=utf8&driverOptions[TrustServerCertificate]=true" \
-        $PHPUNIT_CONTAINER vendor/bin/phpunit $@
+        $PHPUNIT_CONTAINER vendor/bin/phpunit "$@"
 }
 
 do_test_sqlsrv() {
-    do_test_sqlsrv2019 $@
-    do_test_sqlsrv2022 $@
+    do_test_sqlsrv2019 "$@"
+    do_test_sqlsrv2022 "$@"
 }
 
 # SQLite version depends upon the PHP embeded version or linked
@@ -246,7 +246,7 @@ do_test_sqlite() {
         -e DBAL_HOST=127.0.0.1 \
         -e DBAL_PATH="test_db.sqlite" \
         -e DATABASE_URL="pdo-sqlite:///test_db.sqlite" \
-        $PHPUNIT_CONTAINER vendor/bin/phpunit $@
+        $PHPUNIT_CONTAINER vendor/bin/phpunit "$@"
 }
 
 # Run PHPunit tests for all database vendors
@@ -256,14 +256,14 @@ do_test_all() {
     # @todo Temporary deactivated MySQL 5.7 due to a bug.
     # https://github.com/makinacorpus/DbToolsBundle/issues/124
     # do_test_mysql57
-    do_test_mysql80 $@
-    do_test_mysql83 $@
-    do_test_mariadb11 $@
-    do_test_postgresql10 $@
-    do_test_postgresql16 $@
-    do_test_sqlsrv2019 $@
-    do_test_sqlsrv2022 $@
-    do_test_sqlite $@
+    do_test_mysql80 "$@"
+    do_test_mysql83 "$@"
+    do_test_mariadb11 "$@"
+    do_test_postgresql10 "$@"
+    do_test_postgresql16 "$@"
+    do_test_sqlsrv2019 "$@"
+    do_test_sqlsrv2022 "$@"
+    do_test_sqlite "$@"
 }
 
 do_test_notice() {

--- a/dev.sh
+++ b/dev.sh
@@ -4,6 +4,12 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
+if [[ -z "${PHPVER}" ]]; then
+    PHPVER="8-2"
+fi
+
+PHPUNIT_CONTAINER="phpunit-${PHPVER}"
+
 section_title() {
     printf "${RED}\n-------------------------------- ${NC}"
     printf "${RED}$1${NC}"
@@ -30,7 +36,11 @@ do_down() {
 
 do_composer_update() {
     echo 'composer update'
-    docker compose -p db_tools_bundle_test exec phpunit composer update
+    if [[ -z "${LOWEST}" ]]; then
+        docker compose -p db_tools_bundle_test exec $PHPUNIT_CONTAINER composer update
+    else
+        docker compose -p db_tools_bundle_test exec $PHPUNIT_CONTAINER composer update --prefer-lowest
+    fi
 }
 
 # Launch composer checks (for Static analysis & Code style fixer)
@@ -40,13 +50,17 @@ do_checks() {
     do_composer_update
 
     echo 'composer checks'
-    docker compose -p db_tools_bundle_test exec phpunit composer checks
+    docker compose -p db_tools_bundle_test exec $PHPUNIT_CONTAINER composer checks
 }
 
 # Launch PHPUnit tests without any database vendor
 do_unittest() {
     section_title "PHPUnit unit tests"
-    docker compose -p db_tools_bundle_test exec phpunit vendor/bin/phpunit
+    docker compose -p db_tools_bundle_test exec $PHPUNIT_CONTAINER vendor/bin/phpunit
+}
+
+do_ps() {
+    docker compose -p db_tools_bundle_test ps
 }
 
 do_test_mysql57() {
@@ -61,7 +75,7 @@ do_test_mysql57() {
         -e DBAL_ROOT_USER="root" \
         -e DBAL_USER=root \
         -e DATABASE_URL=mysql://root:password@mysql57:3306/test_db?serverVersion=5.7 \
-        phpunit vendor/bin/phpunit $@
+        $PHPUNIT_CONTAINER vendor/bin/phpunit $@
 }
 
 do_test_mysql80() {
@@ -76,7 +90,7 @@ do_test_mysql80() {
         -e DBAL_ROOT_USER=root \
         -e DBAL_USER=root \
         -e DATABASE_URL=mysql://root:password@mysql80:3306/test_db?serverVersion=8 \
-        phpunit vendor/bin/phpunit $@
+        "$PHPUNIT_CONTAINER" vendor/bin/phpunit $@
 }
 
 do_test_mysql83() {
@@ -91,7 +105,7 @@ do_test_mysql83() {
         -e DBAL_ROOT_USER=root \
         -e DBAL_USER=root \
         -e DATABASE_URL=mysql://root:password@mysql83:3306/test_db?serverVersion=8 \
-        phpunit vendor/bin/phpunit $@
+        $PHPUNIT_CONTAINER vendor/bin/phpunit $@
 }
 
 do_test_mariadb11() {
@@ -106,7 +120,7 @@ do_test_mariadb11() {
         -e DBAL_ROOT_USER="root" \
         -e DBAL_USER=root \
         -e DATABASE_URL=mysql://root:password@mariadb11:3306/test_db?serverVersion=mariadb-11.1.3 \
-        phpunit vendor/bin/phpunit $@
+        $PHPUNIT_CONTAINER vendor/bin/phpunit $@
 }
 
 do_test_mysql() {
@@ -130,7 +144,7 @@ do_test_postgresql10() {
         -e DBAL_ROOT_USER=postgres \
         -e DBAL_USER=postgres \
         -e DATABASE_URL="postgresql://postgres:password@postgresql10:5432/test_db?serverVersion=10&charset=utf8" \
-        phpunit vendor/bin/phpunit $@
+        $PHPUNIT_CONTAINER vendor/bin/phpunit $@
 }
 
 do_test_postgresql16() {
@@ -145,7 +159,7 @@ do_test_postgresql16() {
         -e DBAL_ROOT_USER=postgres \
         -e DBAL_USER=postgres \
         -e DATABASE_URL="postgresql://postgres:password@postgresql16:5432/test_db?serverVersion=16&charset=utf8" \
-        phpunit vendor/bin/phpunit $@
+        $PHPUNIT_CONTAINER vendor/bin/phpunit $@
 }
 
 do_test_postgresql() {
@@ -165,7 +179,7 @@ do_test_sqlsrv2019() {
         -e DBAL_ROOT_USER=sa \
         -e DBAL_USER=sa \
         -e DATABASE_URL="pdo-sqlsrv://sa:P%40ssword123@sqlsrv2019:1433/test_db?serverVersion=2019&charset=utf8&driverOptions[TrustServerCertificate]=true" \
-        phpunit vendor/bin/phpunit $@
+        $PHPUNIT_CONTAINER vendor/bin/phpunit $@
 }
 
 do_test_sqlsrv2022() {
@@ -180,7 +194,7 @@ do_test_sqlsrv2022() {
         -e DBAL_ROOT_USER=sa \
         -e DBAL_USER=sa \
         -e DATABASE_URL="pdo-sqlsrv://sa:P%40ssword123@sqlsrv2022:1433/test_db?serverVersion=2022&charset=utf8&driverOptions[TrustServerCertificate]=true" \
-        phpunit vendor/bin/phpunit $@
+        $PHPUNIT_CONTAINER vendor/bin/phpunit $@
 }
 
 do_test_sqlsrv() {
@@ -198,7 +212,7 @@ do_test_sqlite() {
         -e DBAL_HOST=127.0.0.1 \
         -e DBAL_PATH="test_db.sqlite" \
         -e DATABASE_URL="pdo-sqlite:///test_db.sqlite" \
-        phpunit vendor/bin/phpunit $@
+        $PHPUNIT_CONTAINER vendor/bin/phpunit $@
 }
 
 # Run PHPunit tests for all database vendors
@@ -288,6 +302,6 @@ action=${1-}
 if [[ -n $@ ]];then shift;fi
 
 case $action in
-    build|up|down|checks|test_all|unittest|test|composer_update|notice) do_$action "$@";;
+    build|up|down|ps|checks|test_all|unittest|test|composer_update|notice) do_$action "$@";;
     *) do_notice;;
 esac

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,11 +1,28 @@
-version: '3.8'
 services:
-    phpunit:
-        build: ./docker/php
+    phpunit-8-2:
+        build: ./docker/php-8.2
         networks:
             - db-tools-test
         volumes:
             - ./:/var/www
+        environment:
+            PHP_IDE_CONFIG: ${PHP_IDE_CONFIG:-serverName=dbtoolsbundle}
+            XDEBUG_CONFIG: "client_host=host.docker.internal client_port=9000 log=/tmp/xdebug/xdebug.log output_dir=/tmp/xdebug start_with_request=trigger"
+            XDEBUG_MODE: "${XDEBUG_MODE:-debug}"
+        extra_hosts:
+            - "host.docker.internal:host-gateway"
+    phpunit-8-3:
+        build: ./docker/php-8.3
+        networks:
+            - db-tools-test
+        volumes:
+            - ./:/var/www
+        environment:
+            PHP_IDE_CONFIG: ${PHP_IDE_CONFIG:-serverName=dbtoolsbundle}
+            XDEBUG_CONFIG: "client_host=host.docker.internal client_port=9000 log=/tmp/xdebug/xdebug.log output_dir=/tmp/xdebug start_with_request=trigger"
+            XDEBUG_MODE: "${XDEBUG_MODE:-debug}"
+        extra_hosts:
+            - "host.docker.internal:host-gateway"
     mysql57:
         image: mysql:5.7
         restart: 'no'

--- a/docker/php-8.2/Dockerfile
+++ b/docker/php-8.2/Dockerfile
@@ -1,0 +1,36 @@
+FROM php:8.2-fpm-bookworm
+
+# Basic requirements
+RUN apt-get update
+RUN apt-get install -yqq --no-install-recommends default-mysql-client acl iproute2 zip zlib1g-dev libzip-dev \
+    libxml2-dev libpng-dev libghc-curl-dev libldb-dev libldap2-dev gnupg2 libpq-dev sqlite3
+
+# Instaling postgresql-client-16
+RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc| gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg && \
+    sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
+    apt-get update && apt-get install -y postgresql-16
+
+# PHP required extensions
+RUN docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql
+RUN docker-php-ext-install -j$(nproc) pgsql pdo_pgsql pdo mysqli pdo_mysql zip xml gd curl bcmath
+RUN docker-php-ext-enable pdo_pgsql pdo_mysql sodium
+
+# SQL Server support
+ENV ACCEPT_EULA=Y
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+RUN curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
+RUN apt-get update
+RUN apt-get -y --no-install-recommends install msodbcsql18 unixodbc-dev
+RUN pecl install sqlsrv
+RUN pecl install pdo_sqlsrv
+RUN docker-php-ext-enable sqlsrv pdo_sqlsrv
+
+# Install Xdebug
+RUN pecl install xdebug-3.3.2 && docker-php-ext-enable xdebug
+
+# Cleanup.
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+WORKDIR /var/www

--- a/docker/php-8.3/Dockerfile
+++ b/docker/php-8.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm-bookworm
+FROM php:8.3-fpm-bookworm
 
 # Basic requirements
 RUN apt-get update
@@ -24,6 +24,9 @@ RUN apt-get -y --no-install-recommends install msodbcsql18 unixodbc-dev
 RUN pecl install sqlsrv
 RUN pecl install pdo_sqlsrv
 RUN docker-php-ext-enable sqlsrv pdo_sqlsrv
+
+# Install Xdebug
+RUN pecl install xdebug-3.3.2 && docker-php-ext-enable xdebug
 
 # Cleanup.
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
- `-x` option to trigger xdebug
- `-l` option to trigger `--prefer-lowest` when running `composer update`
- `-p x.y` option to change php version (only supports `8.3` and fallbacks to `8.2` for all other values)