### PR TITLE
fix: typo with psr4 folder in iban bic anonymizer

### DIFF
--- a/src/Anonymization/Anonymizer/Core/IbanBicAnonymizer.php
+++ b/src/Anonymization/Anonymizer/Core/IbanBicAnonymizer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Common;
+namespace MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Core;
 
 use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\AbstractMultipleColumnAnonymizer;
 use MakinaCorpus\DbToolsBundle\Helper\Iban;


### PR DESCRIPTION
In composer update, fix the following error:

```
Generating optimized autoload files
Class MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Common\IbanBicAnonymizer located 
in ./vendor/makinacorpus/db-tools-bundle/src/Anonymization/Anonymizer/Core/IbanBicAnonymizer.php 
does not comply with psr-4 autoloading standard. Skipping.
```

It seems a typo using "Common" folder which not exist, instead use the "Core" folder which have all the classes.