### PR TITLE
fix: Extension deprecation

### DIFF
--- a/src/Bridge/Symfony/DependencyInjection/DbToolsExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/DbToolsExtension.php
@@ -10,9 +10,9 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 final class DbToolsExtension extends Extension
 {


### PR DESCRIPTION
Will fix this deprecation-message

`The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "MakinaCorpus\DbToolsBundle\DependencyInjection\DbToolsExtension".`