### PR TITLE
Fix typed property must not be accessed before initialization error when using --list option

### DIFF
--- a/src/Anonymization/Config/Loader/AttributesLoader.php
+++ b/src/Anonymization/Config/Loader/AttributesLoader.php
@@ -38,7 +38,7 @@ class AttributesLoader implements LoaderInterface
             }
 
             $embeddedClassesConfig = [];
-            foreach($metadata->embeddedClasses as $name => $embeddedClass) {
+            foreach ($metadata->embeddedClasses as $name => $embeddedClass) {
                 $className = $embeddedClass['class'];
                 $embeddedClassesConfig[$className] = [];
                 $reflexionClass = new \ReflectionClass($className);

--- a/src/Backupper/SqliteBackupper.php
+++ b/src/Backupper/SqliteBackupper.php
@@ -54,7 +54,7 @@ class SqliteBackupper extends AbstractBackupper
 
         $tables = [];
         foreach ($query->executeQuery() as $table) {
-            if(!\in_array($table['name'], $this->excludedTables)) {
+            if (!\in_array($table['name'], $this->excludedTables)) {
                 $tables[] = $table['name'];
             }
         }

--- a/src/Bridge/Symfony/DependencyInjection/Compiler/DbToolsPass.php
+++ b/src/Bridge/Symfony/DependencyInjection/Compiler/DbToolsPass.php
@@ -29,7 +29,7 @@ class DbToolsPass implements CompilerPassInterface
             }
 
             if (isset($config['anonymization']) && isset($config['anonymization']['yaml'])) {
-                foreach($config['anonymization']['yaml'] as $connectionName => $file) {
+                foreach ($config['anonymization']['yaml'] as $connectionName => $file) {
                     $loaderId = $this->registerYamlLoader($file, $connectionName, $container);
                     $anonymazorFactoryDef->addMethodCall('addConfigurationLoader', [new Reference($loaderId)]);
                 }

--- a/src/Command/RestoreCommand.php
+++ b/src/Command/RestoreCommand.php
@@ -202,6 +202,7 @@ class RestoreCommand extends Command
     private function listBackups(): int
     {
         $this->io->section('Backups list');
+        $this->restorer = $this->restorerFactory->create($this->connectionName);
 
         $backupLists = $this->storage->listBackups(
             $this->connectionName,

--- a/src/Helper/Iban.php
+++ b/src/Helper/Iban.php
@@ -121,9 +121,9 @@ class Iban
         $parts = \str_split($number, 7);
         $rest = 0;
         foreach ($parts as $part) {
-            $rest = ($rest . $part) % 97;
+            $rest = ((int)($rest . $part)) % 97;
         }
-        return $rest;
+        return (int)$rest;
     }
 
     /**

--- a/src/Test/FunctionalTestCase.php
+++ b/src/Test/FunctionalTestCase.php
@@ -64,7 +64,7 @@ abstract class FunctionalTestCase extends UnitTestCase
         $privConnection = $this->createPrivConnection();
         try {
             $privConnection->createSchemaManager()->createDatabase('test_db');
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
 
         } finally {
             $privConnection->close();

--- a/tests/Functional/Command/RestoreCommandTest.php
+++ b/tests/Functional/Command/RestoreCommandTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace MakinaCorpus\DbToolsBundle\Tests\Functional\Command;
 
-use MakinaCorpus\DbToolsBundle\Test\FunctionalKernelTestCase;
-use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Component\Console\Tester\CommandTester;
 use MakinaCorpus\DbToolsBundle\Command\RestoreCommand;
 use MakinaCorpus\DbToolsBundle\Restorer\AbstractRestorer;
 use MakinaCorpus\DbToolsBundle\Restorer\RestorerFactory;
 use MakinaCorpus\DbToolsBundle\Storage\Storage;
+use MakinaCorpus\DbToolsBundle\Test\FunctionalKernelTestCase;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
 
 class RestoreCommandTest extends FunctionalKernelTestCase
 {
@@ -33,9 +33,10 @@ class RestoreCommandTest extends FunctionalKernelTestCase
     }
 
     /**
-     * Creates a command tester with mocked dependencies for listBackups method
+     * Creates a command tester with mocked dependencies for listBackups method.
      *
-     * @param array $backupFiles List of backup files to be returned by storage
+     * @param array $backupFiles
+     *   List of backup files to be returned by storage.
      */
     private function createCommandTester(array $backupFiles = []): CommandTester
     {

--- a/tests/Functional/Command/RestoreCommandTest.php
+++ b/tests/Functional/Command/RestoreCommandTest.php
@@ -7,6 +7,11 @@ namespace MakinaCorpus\DbToolsBundle\Tests\Functional\Command;
 use MakinaCorpus\DbToolsBundle\Test\FunctionalKernelTestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use MakinaCorpus\DbToolsBundle\Command\RestoreCommand;
+use MakinaCorpus\DbToolsBundle\Restorer\AbstractRestorer;
+use MakinaCorpus\DbToolsBundle\Restorer\RestorerFactory;
+use MakinaCorpus\DbToolsBundle\Storage\Storage;
+use PHPUnit\Framework\TestCase;
 
 class RestoreCommandTest extends FunctionalKernelTestCase
 {
@@ -25,5 +30,104 @@ class RestoreCommandTest extends FunctionalKernelTestCase
         $commandTester->execute([]);
 
         self::assertCommandIsSuccessful($commandTester);
+    }
+
+    /**
+     * Creates a command tester with mocked dependencies for listBackups method
+     *
+     * @param array $backupFiles List of backup files to be returned by storage
+     */
+    private function createCommandTester(array $backupFiles = []): CommandTester
+    {
+        // Storage mock returns our test backup files and a fake path
+        $storage = $this->createMock(Storage::class);
+        $storage
+            ->method('listBackups')
+            ->willReturn($backupFiles);
+        $storage
+            ->method('getStoragePath')
+            ->willReturn('/fake/path');
+
+        // Restorer mock just needs to provide a file extension
+        $restorer = $this->createMock(AbstractRestorer::class);
+        $restorer
+            ->method('getExtension')
+            ->willReturn('sql');
+
+        // Factory mock returns our mocked restorer
+        $restorerFactory = $this->createMock(RestorerFactory::class);
+        $restorerFactory
+            ->method('create')
+            ->willReturn($restorer);
+
+        $command = new RestoreCommand(
+            'default',
+            $restorerFactory,
+            $storage,
+            null // timeout
+        );
+
+        return new CommandTester($command);
+    }
+
+    /**
+     * Test listing when no backups are available
+     */
+    public function testListBackupsEmpty(): void
+    {
+        $commandTester = $this->createCommandTester([]);
+
+        $commandTester->execute([
+            '--list' => true,
+        ]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString(
+            'Backups list',
+            $output,
+            'Output should contain the section title "Backups list"'
+        );
+        $this->assertStringContainsString(
+            'There is no backup files available in /fake/path',
+            $output,
+            'Output should display the "no backups" warning message with the correct path'
+        );
+    }
+
+    /**
+     * Test listing with some backup files
+     * Each backup file is represented by [date, filename]
+     */
+    public function testListBackupsWithFiles(): void
+    {
+        // Mock some backup files with date and filename
+        $backupFiles = [
+            ['1 days', 'backup_2024-03-20_10-30-00.sql'],
+            ['2 days', 'backup_2024-03-21_14-45-00.sql'],
+        ];
+
+        $commandTester = $this->createCommandTester($backupFiles);
+
+        $commandTester->execute([
+            '--list' => true,
+        ]);
+
+        // Check that output contains both the section title and our backup files
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString(
+            'Backups list',
+            $output,
+            'Output should start with the section title "Backups list"'
+        );
+        $this->assertStringContainsString(
+            $backupFiles[0][1] . ' (' . $backupFiles[0][0] . ')',
+            $output,
+            'Output should contain the first backup file with its age'
+        );
+        $this->assertStringContainsString(
+            $backupFiles[1][1] . ' (' . $backupFiles[1][0] . ')',
+            $output,
+            'Output should contain the second backup file with its age'
+        );
     }
 }


### PR DESCRIPTION
Hello

When using the `db-tools:restore --list` command, in the `listBackup()` method the `$this->restorer` variable is not inited yet which lead to a fatal error. 
https://github.com/makinacorpus/DbToolsBundle/blob/main/src/Command/RestoreCommand.php#L97

As the restorer is inited lately in the main process 
https://github.com/makinacorpus/DbToolsBundle/blob/main/src/Command/RestoreCommand.php#L110

i added the same call to the factory inside the `listBackups()` method to fix and tests case for the --list option


