### PR TITLE
feat: Add clean command to dev.sh script

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -71,6 +71,12 @@ do_down() {
     do_docker_compose down
 }
 
+# Clean all containers, images and volumes
+do_clean() {
+    section_title "Cleanup containers and images"
+    do_docker_compose down --rmi all --volumes --remove-orphans
+}
+
 do_composer_update() {
     echo 'composer update'
     if [[ -z "${LOWEST}" ]]; then
@@ -325,6 +331,7 @@ do_notice() {
     printf "\n              ${GREEN}./dev.sh test_all --filter AnonymizatorFactoryTest${NC}"
     printf "\n  - ${GREEN}test${NC}: Run PHPUnit tests for a specific database vendors or version"
     printf "\n  - ${GREEN}unittest${NC}: Run PHPUnit tests without any database vendor"
+    printf "\n  - ${GREEN}clean${NC}: Cleanup containers and images"
     printf "\n  - ${GREEN}notice${NC}: Display this help"
     printf "\n"
     printf "\nAvailable options:"
@@ -341,6 +348,6 @@ action=${1-}
 if [[ -n $@ ]];then shift;fi
 
 case $action in
-    build|up|down|ps|checks|test_all|unittest|test|composer_update|notice) do_$action "$@";;
+    build|up|down|ps|checks|test_all|unittest|test|composer_update|notice|clean) do_$action "$@";;
     *) do_notice;;
 esac

--- a/docs/content/contribute/guide.md
+++ b/docs/content/contribute/guide.md
@@ -47,6 +47,12 @@ When you finish to develop, stop the stack with:
 ./dev.sh down
 ```
 
+If you need to clean up everything (containers, images and volumes), you can use:
+
+```sh
+./dev.sh clean
+```
+
 To learn more about `dev.sh` script, launch:
 
 ```sh


### PR DESCRIPTION
Hello

This PR add a new development helper command to completely clean up the Docker environment. This is useful for contributors who want to reset their development environment to a clean state.

The `clean` command performs the following:
- Stops and removes all containers
- Removes all Docker images used by the project
- Removes all associated volumes
- Cleans up any orphaned containers

Usage:
```sh
./dev.sh clean
```

Documentation has been adjusted accordingly to the change.