### PR TITLE
feature: fakerphp/faker integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,8 @@
         "symfony/validator": "^6.3|^7.0"
     },
     "suggest": {
+        "db-tools-bundle/pack-faker": "FakerPHP/Faker bridge anonyzer pack",
+        "db-tools-bundle/pack-fr-fr": "French anonymizers pack",
         "symfony/password-hasher": "In order to use the password hash anonymizer"
     },
     "conflict": {

--- a/src/Anonymization/Anonymizer/AbstractAnonymizer.php
+++ b/src/Anonymization/Anonymizer/AbstractAnonymizer.php
@@ -110,7 +110,41 @@ abstract class AbstractAnonymizer
      *
      * @throws \Exception if any option is invalid.
      */
-    protected function validateOptions(): void {}
+    protected function validateOptions(): void
+    {
+        if ($this->hasSampleSizeOption()) {
+            if ($this->options->has('sample_size')) {
+                $value = $this->options->getInt('sample_size');
+                if ($value <= 0) {
+                    throw new \InvalidArgumentException("'sample_size' option must be a positive integer.");
+                }
+            }
+        }
+    }
+
+    /**
+     * Does this anonymizer has a "sample size" option.
+     */
+    protected function hasSampleSizeOption(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Default sample size, goes along the "sample size" option set to true.
+     */
+    protected function getDefaultSampleSize(): int
+    {
+        return 500;
+    }
+
+    /**
+     * Default sample size, goes along the "sample size" option set to true.
+     */
+    protected function getSampleSize(): int
+    {
+        return $this->options->getInt('sample_size', $this->getDefaultSampleSize());
+    }
 
     /**
      * Initialize your anonymizer.

--- a/src/Anonymization/Anonymizer/AbstractMultipleColumnAnonymizer.php
+++ b/src/Anonymization/Anonymizer/AbstractMultipleColumnAnonymizer.php
@@ -49,6 +49,8 @@ abstract class AbstractMultipleColumnAnonymizer extends AbstractTableAnonymizer
     #[\Override]
     protected function validateOptions(): void
     {
+        parent::validateOptions();
+
         if (0 === \count($this->options->all())) {
             throw new \InvalidArgumentException("You must provide at least one option.");
         }

--- a/src/Anonymization/Anonymizer/Core/IbanBicAnonymizer.php
+++ b/src/Anonymization/Anonymizer/Core/IbanBicAnonymizer.php
@@ -29,12 +29,6 @@ class IbanBicAnonymizer extends AbstractMultipleColumnAnonymizer
     {
         parent::validateOptions();
 
-        if ($this->options->has('sample_size')) {
-            $value = $this->options->getInt('sample_size');
-            if ($value <= 0) {
-                throw new \InvalidArgumentException("'sample_size' option must be a positive integer.");
-            }
-        }
         if ($this->options->has('country')) {
             $value = $this->options->getString('country');
             if (!\ctype_alpha($value) || 2 !== \strlen($value)) {
@@ -53,9 +47,15 @@ class IbanBicAnonymizer extends AbstractMultipleColumnAnonymizer
     }
 
     #[\Override]
+    protected function hasSampleSizeOption(): bool
+    {
+        return true;
+    }
+
+    #[\Override]
     protected function getSamples(): array
     {
-        $sampleSize = $this->options->getInt('sample_size', 500);
+        $sampleSize = $this->getSampleSize();
         $countryCode = $this->options->getString('country', 'FR');
 
         // @todo, pas d'options, pas de count ni de country, désolé.

--- a/src/Attribute/AsAnonymizer.php
+++ b/src/Attribute/AsAnonymizer.php
@@ -14,6 +14,18 @@ class AsAnonymizer
         public string $name,
         public string $pack,
         public ?string $description = null,
+        /**
+         * @var array<string>
+         *   Array of class or interface names required for this anonymizer to work.
+         *   Anonymizers whose requirements are not met will not be usable and raise
+         *   an error in listing.
+         */
+        public array $requires = [],
+        /**
+         * @var array<string>
+         *   List of composer dependencies for filling the requirements.
+         */
+        public ?array $dependencies = [],
     ) {}
 
     public function id(): string
@@ -21,5 +33,15 @@ class AsAnonymizer
         // Id is 'pack.name' except for anonymiser from core
         // which don't have prefix.
         return ('core' !== $this->pack ? $this->pack . '.' : '') . $this->name;
+    }
+
+    public function missingRequirements(): bool
+    {
+        foreach ($this->requires as $classOrInterfaceName) {
+            if (!\class_exists($classOrInterfaceName) && !\interface_exists($classOrInterfaceName)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/Command/Anonymization/AnonymizerListCommand.php
+++ b/src/Command/Anonymization/AnonymizerListCommand.php
@@ -43,7 +43,12 @@ class AnonymizerListCommand extends Command
                 $list[$metadata->pack] = [];
             }
 
-            $list[$metadata->pack]['<info>' . $metadata->id() . '</info>'] = $metadata->description;
+            $description = $metadata->description;
+            if ($metadata->missingRequirements()) {
+                $description .= "\n" . \sprintf('<error>Dependencies are missing: "%s"</error>', \implode('", "', $metadata->dependencies));
+            }
+
+            $list[$metadata->pack]['<info>' . $metadata->id() . '</info>'] = $description;
         }
 
         \array_walk($list, fn (array &$anonymizers) => \ksort($anonymizers, SORT_STRING));

--- a/src/Helper/LoremIpsum.php
+++ b/src/Helper/LoremIpsum.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Lorem Ipsum Generator
  *

--- a/tests/Functional/Anonymizer/Core/AddressAnonymizerTest.php
+++ b/tests/Functional/Anonymizer/Core/AddressAnonymizerTest.php
@@ -2,13 +2,10 @@
 
 declare(strict_types=1);
 
-namespace DbToolsBundle\PackFrFR\Tests\Functional\Anonymizer;
+namespace DbToolsBundle\PackFrFR\Tests\Functional\Anonymizer\Core;
 
-use MakinaCorpus\DbToolsBundle\Anonymization\Config\AnonymizationConfig;
-use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizator;
-use MakinaCorpus\DbToolsBundle\Anonymization\Config\AnonymizerConfig;
-use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\AnonymizerRegistry;
 use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Options;
+use MakinaCorpus\DbToolsBundle\Anonymization\Config\AnonymizerConfig;
 use MakinaCorpus\DbToolsBundle\Test\FunctionalTestCase;
 
 class AddressAnonymizerTest extends FunctionalTestCase


### PR DESCRIPTION
Two new anonymizers:
 - First one, an address anonymizer, but using faker. 
 - Second one, an "any faker method" anonymizer, which awaits a `method` option, that will then dynamically call this method name on the faker generator for building the sample table.

I also took the liberty of refactoring the sample size handling, in order for pretty much all anonymizers to be able to use it.

The `fakerphp/faker` dependency is optional, in `suggests`, in order to make it work gracefully, I added a warning when a dependency is missing in `anonymization:list` command.