### PR TITLE
Anonymization - Mysql 8.0 - fix addAnonymizerIdColumnMySql

### DIFF
--- a/src/Anonymization/Anonymizator.php
+++ b/src/Anonymization/Anonymizator.php
@@ -687,7 +687,7 @@ class Anonymizator implements LoggerAwareInterface
             } else {
                 $this->databaseSession->executeStatement(
                     <<<SQL
-                    CREATE FUNCTION IF NOT EXISTS ?::id() RETURNS BIGINT
+                    CREATE FUNCTION ?::id() RETURNS BIGINT
                     DETERMINISTIC
                     BEGIN
                         SELECT `value` + 1 INTO @value FROM ?::table LIMIT 1;


### PR DESCRIPTION
'CREATE FUNCTION IF NOT EXISTS' is not strictly compatible with MYSQL 8.0 (beginning with MySQL 8.0.29)