### PR TITLE
Add new AbstractSingleColumnAnonymizer anonymizer base class

### DIFF
--- a/src/Anonymization/Anonymizer/AbstractEnumAnonymizer.php
+++ b/src/Anonymization/Anonymizer/AbstractEnumAnonymizer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer;
 
+use MakinaCorpus\QueryBuilder\Expression;
 use MakinaCorpus\QueryBuilder\Vendor;
 use MakinaCorpus\QueryBuilder\Query\Select;
 use MakinaCorpus\QueryBuilder\Query\Update;
@@ -12,7 +13,7 @@ use MakinaCorpus\QueryBuilder\Query\Update;
  * Can not be use alone, check FrFR/PrenomAnonymizer for an
  * example on how to extend this Anonymizer for your need.
  */
-abstract class AbstractEnumAnonymizer extends AbstractAnonymizer
+abstract class AbstractEnumAnonymizer extends AbstractSingleColumnAnonymizer
 {
     private ?string $sampleTableName = null;
 
@@ -43,7 +44,7 @@ abstract class AbstractEnumAnonymizer extends AbstractAnonymizer
     }
 
     #[\Override]
-    public function anonymize(Update $update): void
+    public function createAnonymizeExpression(Update $update): Expression
     {
         $expr = $update->expression();
 
@@ -86,7 +87,7 @@ abstract class AbstractEnumAnonymizer extends AbstractAnonymizer
             $joinAlias
         );
 
-        $update->set($this->columnName, $expr->column('value', $joinAlias));
+        return $expr->column('value', $joinAlias);
     }
 
     #[\Override]

--- a/src/Anonymization/Anonymizer/AbstractSingleColumnAnonymizer.php
+++ b/src/Anonymization/Anonymizer/AbstractSingleColumnAnonymizer.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer;
+
+use MakinaCorpus\QueryBuilder\Expression;
+use MakinaCorpus\QueryBuilder\Query\Update;
+
+/**
+ * Anonymizer that targets a single column.
+ *
+ * Using this as a base class will allow more complex anonymizers to re-use
+ * the generated SQL code of this anonymizer in more complex SQL expressions.
+ */
+abstract class AbstractSingleColumnAnonymizer extends AbstractAnonymizer
+{
+    #[\Override]
+    final public function anonymize(Update $update): void
+    {
+        $update->set($this->columnName, $this->createAnonymizeExpression($update));
+    }
+
+    /**
+     * Create anonymization SQL expression, the expression must return a value, even if null.
+     */
+    abstract public function createAnonymizeExpression(Update $update): Expression;
+}

--- a/src/Anonymization/Anonymizer/Core/ConstantAnonymizer.php
+++ b/src/Anonymization/Anonymizer/Core/ConstantAnonymizer.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Core;
 
-use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\AbstractAnonymizer;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\AbstractSingleColumnAnonymizer;
 use MakinaCorpus\DbToolsBundle\Attribute\AsAnonymizer;
+use MakinaCorpus\QueryBuilder\Expression;
 use MakinaCorpus\QueryBuilder\Query\Update;
 
 #[AsAnonymizer(
@@ -18,7 +19,7 @@ use MakinaCorpus\QueryBuilder\Query\Update;
         - `type`: a SQL type for the given value (default is 'text')
     TXT
 )]
-class ConstantAnonymizer extends AbstractAnonymizer
+class ConstantAnonymizer extends AbstractSingleColumnAnonymizer
 {
     #[\Override]
     protected function validateOptions(): void
@@ -27,18 +28,15 @@ class ConstantAnonymizer extends AbstractAnonymizer
     }
 
     #[\Override]
-    public function anonymize(Update $update): void
+    public function createAnonymizeExpression(Update $update): Expression
     {
         $expr = $update->expression();
 
-        $update->set(
-            $this->columnName,
-            $this->getSetIfNotNullExpression(
-                $expr->cast(
-                    $this->options->get('value'),
-                    $this->options->get('type', 'text')
-                )
-            ),
+        return $this->getSetIfNotNullExpression(
+            $expr->cast(
+                $this->options->get('value'),
+                $this->options->get('type', 'text')
+            )
         );
     }
 }

--- a/src/Anonymization/Anonymizer/Core/EmailAnonymizer.php
+++ b/src/Anonymization/Anonymizer/Core/EmailAnonymizer.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Core;
 
-use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\AbstractAnonymizer;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\AbstractSingleColumnAnonymizer;
 use MakinaCorpus\DbToolsBundle\Attribute\AsAnonymizer;
+use MakinaCorpus\QueryBuilder\Expression;
 use MakinaCorpus\QueryBuilder\Vendor;
 use MakinaCorpus\QueryBuilder\Query\Update;
 
@@ -17,7 +18,7 @@ use MakinaCorpus\QueryBuilder\Query\Update;
     Values are salted to prevent reversing the hash with option 'use_salt' (default: true).
     TXT
 )]
-class EmailAnonymizer extends AbstractAnonymizer
+class EmailAnonymizer extends AbstractSingleColumnAnonymizer
 {
     #[\Override]
     protected function validateOptions(): void
@@ -27,7 +28,7 @@ class EmailAnonymizer extends AbstractAnonymizer
     }
 
     #[\Override]
-    public function anonymize(Update $update): void
+    public function createAnonymizeExpression(Update $update): Expression
     {
         $expr = $update->expression();
 
@@ -43,16 +44,13 @@ class EmailAnonymizer extends AbstractAnonymizer
             $emailHashExpr = $expr->md5($userExpr);
         }
 
-        $update->set(
-            $this->columnName,
-            $this->getSetIfNotNullExpression(
-                $expr->concat(
-                    'anon-',
-                    $emailHashExpr,
-                    '@',
-                    $this->options->get('domain', 'example.com'),
-                ),
-            ),
+        return $this->getSetIfNotNullExpression(
+            $expr->concat(
+                'anon-',
+                $emailHashExpr,
+                '@',
+                $this->options->get('domain', 'example.com'),
+            )
         );
     }
 }

--- a/src/Anonymization/Anonymizer/Core/NullAnonymizer.php
+++ b/src/Anonymization/Anonymizer/Core/NullAnonymizer.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Core;
 
-use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\AbstractAnonymizer;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\AbstractSingleColumnAnonymizer;
 use MakinaCorpus\DbToolsBundle\Attribute\AsAnonymizer;
+use MakinaCorpus\QueryBuilder\Expression;
 use MakinaCorpus\QueryBuilder\Query\Update;
 
 #[AsAnonymizer(
@@ -13,15 +14,11 @@ use MakinaCorpus\QueryBuilder\Query\Update;
     pack: 'core',
     description: 'Set to NULL'
 )]
-class NullAnonymizer extends AbstractAnonymizer
+class NullAnonymizer extends AbstractSingleColumnAnonymizer
 {
     #[\Override]
-    public function anonymize(Update $update): void
+    public function createAnonymizeExpression(Update $update): Expression
     {
-        $expr = $update->expression();
-        $update->set(
-            $this->columnName,
-            $expr->null(),
-        );
+        return $update->expression()->null();
     }
 }

--- a/src/Anonymization/Anonymizer/Core/PasswordAnonymizer.php
+++ b/src/Anonymization/Anonymizer/Core/PasswordAnonymizer.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Core;
 
-use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\AbstractAnonymizer;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\AbstractSingleColumnAnonymizer;
 use MakinaCorpus\DbToolsBundle\Attribute\AsAnonymizer;
 use MakinaCorpus\DbToolsBundle\Error\MissingDependencyException;
+use MakinaCorpus\QueryBuilder\Expression;
 use MakinaCorpus\QueryBuilder\Query\Update;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
 
@@ -18,7 +19,7 @@ use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
     Options are 'algorithm' (default 'auto') and 'password' (default 'password').
     TXT
 )]
-class PasswordAnonymizer extends AbstractAnonymizer
+class PasswordAnonymizer extends AbstractSingleColumnAnonymizer
 {
     #[\Override]
     protected function validateOptions(): void
@@ -45,7 +46,7 @@ class PasswordAnonymizer extends AbstractAnonymizer
     }
 
     #[\Override]
-    public function anonymize(Update $update): void
+    public function createAnonymizeExpression(Update $update): Expression
     {
         $algorithm = $this->options->getString('algorithm', 'auto');
         $password = $this->options->getString('password', 'password');
@@ -56,11 +57,6 @@ class PasswordAnonymizer extends AbstractAnonymizer
         $passwordHasher = $passwordHasherFactory->getPasswordHasher($algorithm);
         $hashedPassword = $passwordHasher->hash($password);
 
-        $update->set(
-            $this->columnName,
-            $this->getSetIfNotNullExpression(
-                $hashedPassword
-            )
-        );
+        return $this->getSetIfNotNullExpression($hashedPassword);
     }
 }


### PR DESCRIPTION
This new `AbstractSingleColumnAnonymizer` class introduces a new `createAnonymizeExpression(Update $update): Expression` public method which opens, for later, anonymizer code re-use in more complex expressions.

This will later allow anonymizers generated from configuration files without PHP code to allow users to write complex string patterns embedding other anonymizers expressions, and thus generate meaningful text.