### PR TITLE
feature: string pattern anonymizer, build complex strings by fetching values from other anonymizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## Next
+
+* [feature] 🌟 String pattern anonymizer, build complex strings by fetching values from other anonymizers.
+
 ## 2.0.3
 
-* [FIX] Fix anonymization for MySQL version >=8.0 but <8.0.29 (#220).
+* [fix] Fix anonymization for MySQL version >=8.0 but <8.0.29 (#220).
 * [doc] Fix connection string examples (#219).
 
 ## 2.0.2

--- a/docs/content/anonymization/core-anonymizers.md
+++ b/docs/content/anonymization/core-anonymizers.md
@@ -13,6 +13,7 @@ This page list all *Anonymizers* provided by *DbToolsBundle*.
 <!--@include: ./core-anonymizers/constant.md-->
 <!--@include: ./core-anonymizers/md5.md-->
 <!--@include: ./core-anonymizers/string.md-->
+<!--@include: ./core-anonymizers/pattern.md-->
 <!--@include: ./core-anonymizers/lastname.md-->
 <!--@include: ./core-anonymizers/firstname.md-->
 <!--@include: ./core-anonymizers/lorem-ipsum.md-->

--- a/docs/content/anonymization/core-anonymizers/pattern.md
+++ b/docs/content/anonymization/core-anonymizers/pattern.md
@@ -1,0 +1,81 @@
+## String pattern
+
+Anonymize by building text values using other anonymizers to fill holes in text.
+
+@@@ standalone docker
+
+```yaml [YAML]
+# db_tools.config.yaml
+anonymization:
+    default:
+        customer:
+            biography:
+                anonymizer: pattern
+                options: {value: '{firstname} {lastname} lives in {address:locality} in {address:country}, he has [2,7] cats.'}
+  #...
+```
+
+@@@
+@@@ symfony
+
+::: code-group
+```php [Attribute]
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use MakinaCorpus\DbToolsBundle\Attribute\Anonymize;
+
+#[ORM\Entity()]
+#[ORM\Table(name: 'customer')]
+class Customer
+{
+    // ...
+
+    #[ORM\Column]
+    #[Anonymize(type: 'pattern', options: ['value' => '{firstname} {lastname} lives in {address:locality} in {address:country}, he has [2,7] cats.'])] // [!code ++]
+    private ?string $biography = null;
+}
+```
+
+```yml [YAML]
+# config/anonymization.yaml
+
+customer:
+    biography:
+        anonymizer: pattern
+        options: {value: '{firstname} {lastname} lives in {address:locality} in {address:country}, he has [2,7] cats.'}
+#...
+```
+:::
+
+@@@
+
+### Integer range
+
+By adding `[MIN,MAX]` anywhere in your text, it will be replaced by a random integer
+in the given range. For example `"I want [7,111] apples"`.
+
+You can use negative integers such as `[-10,10]` or even a fully negative integer
+range `[-127,-34]`.
+
+### Single value from another anonymizer
+
+By adding `{ANONYMIZER}` anywhere in your text, it will be replaced by a random value
+given by the anonymizer. For example `"My email address is {email}, what's yours?"`.
+
+:::warning
+The target anonymizer must not be an multi-column anonymizer.
+:::
+
+### Column value from a multi-column anonymizer
+
+By adding `{ANONYMIZER:COLUMN}` anywhere in your text, it will be replaced by a random
+value for the named column given by the anonymizer. For example, `"The country I live into is {address:country}."`.
+
+If you use more than one column of the same anonymizer in the same text value, the same
+generated row from the target anonymizer will be used. For example, this text will give
+a consistent result: `"The country I live in {address:locality} in {address:country}."`.
+
+:::warning
+The target anonymizer must be a multi-column anonymizer.
+:::

--- a/src/Anonymization/Anonymizer/AnonymizerRegistry.php
+++ b/src/Anonymization/Anonymizer/AnonymizerRegistry.php
@@ -27,6 +27,7 @@ class AnonymizerRegistry
         Core\NullAnonymizer::class,
         Core\PasswordAnonymizer::class,
         Core\StringAnonymizer::class,
+        Core\StringPatternAnonymizer::class,
     ];
 
     /** @var array<string, string> */
@@ -71,7 +72,14 @@ class AnonymizerRegistry
     ): AbstractAnonymizer {
         $className = $this->getAnonymizerClass($name);
 
-        return new $className($config->table, $config->targetName, $databaseSession, $options);
+        $ret = new $className($config->table, $config->targetName, $databaseSession, $options);
+        \assert($ret instanceof AbstractAnonymizer);
+
+        if ($ret instanceof WithAnonymizerRegistry) {
+            $ret->setAnonymizerRegistry($this);
+        }
+
+        return $ret;
     }
 
     /**

--- a/src/Anonymization/Anonymizer/Core/StringPatternAnonymizer.php
+++ b/src/Anonymization/Anonymizer/Core/StringPatternAnonymizer.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Core;
+
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\AbstractAnonymizer;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\AbstractEnumAnonymizer;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\AbstractMultipleColumnAnonymizer;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\AbstractSingleColumnAnonymizer;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Options;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Pattern\IntRangePart;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Pattern\Part;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Pattern\RawPart;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Pattern\RefPart;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Pattern\StringPattern;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\WithAnonymizerRegistry;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\WithAnonymizerRegistryTrait;
+use MakinaCorpus\DbToolsBundle\Anonymization\Config\AnonymizerConfig;
+use MakinaCorpus\DbToolsBundle\Attribute\AsAnonymizer;
+use MakinaCorpus\DbToolsBundle\Error\ConfigurationException;
+use MakinaCorpus\QueryBuilder\Expression;
+use MakinaCorpus\QueryBuilder\Query\Update;
+
+/**
+ * Creates a CONCAT(...) expression which is filled with all parts
+ * of a generated string pattern, using other anonymizers.
+ *
+ * Delta that you will encounter in anonymizers is an information
+ * that allows the user to create more than one JOIN statement for
+ * the same multiple column anonymizer. Per default, it's always 0
+ * and all columns from a same row will be shared for a single
+ * updated line, keeping consistency.
+ */
+#[AsAnonymizer(
+    name: 'pattern',
+    pack: 'core',
+    description: <<<TXT
+    Use a string pattern to build a value using other anonymizers.
+    It can contain:
+      - [min,max]: randomly select and integer inside the given range,
+      - {pack.anonymizer} randomly fetch a value from the given anonymizer,
+      - {pack.anonymizer:column} randomly fetch a value from the given column in the given anonymizer.
+    TXT,
+)]
+class StringPatternAnonymizer extends AbstractSingleColumnAnonymizer implements WithAnonymizerRegistry
+{
+    use WithAnonymizerRegistryTrait;
+
+    private ?StringPattern $pattern = null;
+
+    /**
+     * Child anonymizers, populated during initialize() call in order to be
+     * able to initialize them at the same time.
+     *
+     * It is then being used during clean() for cleanup, then dropped.
+     *
+     * @var array<string, AbstractAnonymizer>
+     */
+    private $childAnonymizers = [];
+
+    #[\Override]
+    protected function validateOptions(): void
+    {
+        // This will lazy create the StringPattern instance, which will parse
+        // the value and raise ConfigurationException in case of an invalid
+        // user input.
+        $this->getPattern();
+    }
+
+    #[\Override]
+    public function initialize(): void
+    {
+        parent::initialize();
+
+        // Initialize all child anonymizers. We need to initialized each column
+        // anonymizer only once, and give it columns we will need as options.
+        $columns = [];
+        foreach ($this->getPattern()->parts as $part) {
+            if ($part instanceof RefPart) {
+                if ($part->column) {
+                    $columns[$part->id][$part->column] = $part->column;
+                } elseif (!\array_key_exists($part->id, $columns)) {
+                    $columns[$part->id] = [];
+                }
+            }
+        }
+        foreach ($columns as $name => $columns) {
+            if (!$columns) {
+                $this->getAnonymizer($name)->initialize();
+            } else {
+                $this->getAnonymizer($name, new Options($columns))->initialize();
+            }
+        }
+    }
+
+    #[\Override]
+    public function createAnonymizeExpression(Update $update): Expression
+    {
+        $expr = $update->expression();
+
+        $expressions = [];
+        foreach ($this->getPattern()->parts as $part) {
+            \assert($part instanceof Part);
+
+            if ($part instanceof IntRangePart) {
+                // Integer anonymizer doesn't require any initialization so we
+                // can safely do this, without any prior initialization. For
+                // each range we have in the pattern, options will be different
+                // so we need to create as many instances as we have ranges.
+                $childAnonymizer = $this->getAnonymizer(
+                    'integer',
+                    new Options(
+                        [
+                        'min' => $part->start,
+                        'max' => $part->stop,
+                    ],
+                    )
+                );
+                \assert($childAnonymizer instanceof AbstractSingleColumnAnonymizer);
+
+                $expressions[] = $childAnonymizer->createAnonymizeExpression($update);
+
+                continue;
+            }
+
+            if ($part instanceof RawPart) {
+                $expressions[] = $expr->value($part->string, 'text');
+
+                continue;
+            }
+
+            if ($part instanceof RefPart) {
+                // Anonymizer was prepolulated with options during initialize()
+                // which makes passing any options useless (the cached instance
+                // will be retrieved, already carries options).
+                $childAnonymizer = $this->getAnonymizer($part->id, null, $part->delta);
+
+                if ($part->column) {
+                    if (!$childAnonymizer instanceof AbstractMultipleColumnAnonymizer) {
+                        throw new ConfigurationException(\sprintf("Anonymizer '%s' is not a single value anonymizer.", $part->id));
+                    }
+
+                    $joinAlias = $childAnonymizer->addJoinToQuery($update);
+                    $expressions[] = $expr->column($part->column, $joinAlias);
+
+                    continue;
+                }
+
+                if ($childAnonymizer instanceof AbstractSingleColumnAnonymizer) {
+                    $expressions[] = $childAnonymizer->createAnonymizeExpression($update);
+
+                    continue;
+                }
+            }
+        }
+
+        return $expr->concat(...$expressions);
+    }
+
+    #[\Override]
+    public function clean(): void
+    {
+        try {
+            // Clean all child anonymizers.
+            foreach ($this->childAnonymizers as $anonymizer) {
+                \assert($anonymizer instanceof AbstractAnonymizer);
+                $anonymizer->clean();
+            }
+            $this->childAnonymizers = [];
+        } finally {
+            parent::clean();
+        }
+    }
+
+    /**
+     * Get string pattern.
+     */
+    private function getPattern(): StringPattern
+    {
+        return $this->pattern ??= new StringPattern($this->options->getString('pattern', null, true));
+    }
+
+    /**
+     * Create child anonymizer.
+     */
+    private function getAnonymizer(string $anonymizer, ?Options $options = null, int $delta = 0): AbstractAnonymizer
+    {
+        $key = \sprintf("%s[%d]", $anonymizer, $delta);
+
+        if ($ret = $this->childAnonymizers[$key] ?? null) {
+            return $ret;
+        }
+
+        $config = new AnonymizerConfig($this->tableName, $this->columnName, $anonymizer, new Options());
+
+        return $this->childAnonymizers[$key] = $this
+            ->getAnonymizerRegistry()
+            ->createAnonymizer(
+                $anonymizer,
+                $config,
+                $options ?? new Options(),
+                $this->databaseSession
+            )
+        ;
+    }
+}

--- a/src/Anonymization/Anonymizer/Pattern/IntRangePart.php
+++ b/src/Anonymization/Anonymizer/Pattern/IntRangePart.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Pattern;
+
+class IntRangePart implements Part
+{
+    public function __construct(
+        public readonly int $start,
+        public readonly int $stop,
+    ) {}
+
+    /**
+     * @internal
+     *   Mostly used in unit tests.
+     */
+    #[\Override]
+    public function __toString(): string
+    {
+        return \sprintf("intrange:[%d,%d]", $this->start, $this->stop);
+    }
+}

--- a/src/Anonymization/Anonymizer/Pattern/Part.php
+++ b/src/Anonymization/Anonymizer/Pattern/Part.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Pattern;
+
+interface Part {}

--- a/src/Anonymization/Anonymizer/Pattern/RawPart.php
+++ b/src/Anonymization/Anonymizer/Pattern/RawPart.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Pattern;
+
+class RawPart implements Part
+{
+    public function __construct(
+        public readonly string $string,
+    ) {}
+
+    /**
+     * @internal
+     *   Mostly used in unit tests.
+     */
+    #[\Override]
+    public function __toString(): string
+    {
+        return '"' . $this->string . '"';
+    }
+}

--- a/src/Anonymization/Anonymizer/Pattern/RefPart.php
+++ b/src/Anonymization/Anonymizer/Pattern/RefPart.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Pattern;
+
+class RefPart implements Part
+{
+    public readonly string $id;
+
+    public function __construct(
+        public readonly string $anonymizerId,
+        public readonly ?string $column = null,
+        public readonly ?string $packId = null,
+        public readonly int $delta = 0
+    ) {
+        if ('core' === $this->packId || null === $this->packId) {
+            $this->id = $anonymizerId;
+        } else {
+            $this->id = \sprintf("%s.%s", $this->packId, $this->anonymizerId);
+        }
+    }
+
+    /**
+     * @internal
+     *   Mostly used in unit tests.
+     */
+    #[\Override]
+    public function __toString(): string
+    {
+        return \sprintf("ref:{%s.%s:%s}[%d]", $this->packId, $this->anonymizerId, $this->column ?? 0, $this->delta);
+    }
+}

--- a/src/Anonymization/Anonymizer/Pattern/StringPattern.php
+++ b/src/Anonymization/Anonymizer/Pattern/StringPattern.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Pattern;
+
+use MakinaCorpus\DbToolsBundle\Error\ConfigurationException;
+
+class StringPattern
+{
+    private const GRAMMAR = '@(
+            \[[^\]]*\]|     # Range
+            \{[^\{\}]*\}    # Reference
+        )@x';
+
+    // Matches [n,m], [n;m], [n:m], [n-m]
+    private const GRAMMAR_RANGE = '@\[((-|)\d+)[\:\;\-\,\-]((-|)\d+)\]@';
+    // Matches {foo}, {foo.bar}, {bar:baz}, {foo.bar:baz}
+    private const GRAMMAR_REF = '@{([^\.\:]+)(\.[^\:]+|)(\:.+|)}@';
+
+    /** array<Part> */
+    public readonly array $parts;
+
+    public function __construct(
+        public readonly string $raw,
+        public readonly ?string $packId = null,
+    ) {
+        $this->parts = $this->parseString($this->raw);
+    }
+
+    private function parseString(string $string): array
+    {
+        $ret = [];
+        $length = \strlen($string);
+        $maxOffset = 0;
+
+        $matches = [];
+        if (\preg_match_all(self::GRAMMAR, $string, $matches, \PREG_OFFSET_CAPTURE)) {
+            foreach ($matches[0] as $match) {
+
+                $text = $match[0];
+                $first = $text[0];
+                $startOffset = (int) $match[1];
+                $stopOffset = $startOffset + \strlen($text);
+
+                // Considering they are in order, if there is a gap between
+                // max offset until now and this match own starting offset,
+                // then the gap between the two is a raw string.
+                if ($maxOffset + 1 < $startOffset) {
+                    if (0 === $maxOffset) {
+                        // Header raw string.
+                        $ret[] = new RawPart(\substr($string, 0, $startOffset));
+                    } else {
+                        $ret[] = new RawPart(\substr($string, $maxOffset, $startOffset - $maxOffset));
+                    }
+                }
+
+                // Will help fetching trailing data that is not matched by regex.
+                if ($stopOffset > $maxOffset) {
+                    $maxOffset = $stopOffset;
+                }
+
+                if ('[' === $first) {
+                    $sub = [];
+                    if (\preg_match(self::GRAMMAR_RANGE, $text, $sub)) {
+                        $start = \intval($sub[1]);
+                        $stop = \intval($sub[3]);
+                        if ($start <= $stop) {
+                            $ret[] = new IntRangePart($start, $stop);
+                        } else {
+                            $ret[] = new IntRangePart($stop, $start);
+                        }
+                    } else {
+                        throw new ConfigurationException(\sprintf("Invalid range at offset %d in pattern: %s", $startOffset, $string));
+                    }
+                } elseif ('{' === $first) {
+                    if (\preg_match(self::GRAMMAR_REF, $text, $sub)) {
+                        if ($sub[2]) {
+                            $packId = $sub[1];
+                            $anonymizerId = \substr($sub[2], 1);
+                        } else {
+                            $packId = $this->packId;
+                            $anonymizerId = $sub[1];
+                        }
+                        if ($sub[3]) {
+                            $column = \substr($sub[3], 1);
+                        } else {
+                            $column = null;
+                        }
+                        $ret[] = new RefPart($anonymizerId, $column, $packId);
+                    } else {
+                        throw new ConfigurationException(\sprintf("Invalid anonymizer reference at offset %d in pattern: %s", $startOffset, $string));
+                    }
+                } else {
+                    // Should not happen.
+                    throw new \Exception("Invalid regex.");
+                }
+            }
+
+            // Catch trailing data.
+            if ($maxOffset < $length - 1) {
+                $ret[] = new RawPart(\substr($string, $maxOffset));
+            }
+        } else {
+            $ret[] = new RawPart($string);
+        }
+
+        return $ret;
+    }
+}

--- a/src/Anonymization/Anonymizer/WithAnonymizerRegistry.php
+++ b/src/Anonymization/Anonymizer/WithAnonymizerRegistry.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer;
+
+interface WithAnonymizerRegistry
+{
+    public function setAnonymizerRegistry(AnonymizerRegistry $anonymizerRegistry): void;
+}

--- a/src/Anonymization/Anonymizer/WithAnonymizerRegistryTrait.php
+++ b/src/Anonymization/Anonymizer/WithAnonymizerRegistryTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer;
+
+trait WithAnonymizerRegistryTrait /* implements WithAnonymizerRegistry */
+{
+    private AnonymizerRegistry $anonymizerRegistry;
+
+    #[\Override]
+    public function setAnonymizerRegistry(AnonymizerRegistry $anonymizerRegistry): void
+    {
+        $this->anonymizerRegistry = $anonymizerRegistry;
+    }
+
+    protected function getAnonymizerRegistry(): AnonymizerRegistry
+    {
+        return $this->anonymizerRegistry ?? throw new \LogicException(\sprintf("Did you forget to call %s::getAnonymizerRegistry()", static::class));
+    }
+}

--- a/tests/Functional/Anonymizer/Core/StringPatternAnonymizerTest.php
+++ b/tests/Functional/Anonymizer/Core/StringPatternAnonymizerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MakinaCorpus\DbToolsBundle\Tests\Functional\Anonymizer\Core;
+
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Options;
+use MakinaCorpus\DbToolsBundle\Anonymization\Config\AnonymizerConfig;
+use MakinaCorpus\DbToolsBundle\Test\FunctionalTestCase;
+
+class StringPatternAnonymizerTest extends FunctionalTestCase
+{
+    /** @before */
+    protected function createTestData(): void
+    {
+        $this->createOrReplaceTable(
+            'table_test',
+            [
+                'id' => 'integer',
+                'data' => 'text',
+            ],
+            [
+                [
+                    'id' => 1,
+                    'data' => "Foo value",
+                ],
+                [
+                    'id' => 2,
+                    'data' => "Bar value",
+                ],
+                [
+                    'id' => 3,
+                    'data' => "Fizz value",
+                ],
+                [
+                    'id' => 4,
+                ],
+            ],
+        );
+    }
+
+    public function testAnonymize(): void
+    {
+        $anonymizator = $this->createAnonymizatorWithConfig(
+            new AnonymizerConfig(
+                'table_test',
+                'data',
+                'pattern',
+                new Options(['pattern' => "Range [1-1000] for {email} and {address:locality} in {address:country}"])
+            ),
+        );
+
+        self::assertSame(
+            "Foo value",
+            (string) $this->getDatabaseSession()->executeQuery('select data from table_test where id = 1')->fetchOne(),
+        );
+
+        $anonymizator->anonymize();
+
+        $datas = $this->getDatabaseSession()->executeQuery('select data from table_test order by id asc')->fetchFirstColumn();
+
+        $checkRegex = '/^Range \d+ for [a-z0-9-]+@example\.com and .+ in [\sa-z-]+$/i';
+
+        $data = (string) $datas[0];
+        self::assertNotNull($data);
+        self::assertNotSame("Foo value", $data);
+        self::assertMatchesRegularExpression($checkRegex, $data);
+
+        $data = (string) $datas[1];
+        self::assertNotNull($data);
+        self::assertNotSame("Baz value", $data);
+        self::assertMatchesRegularExpression($checkRegex, $data);
+
+        $data = (string) $datas[2];
+        self::assertNotNull($data);
+        self::assertNotSame("Fizz value", $data);
+        self::assertMatchesRegularExpression($checkRegex, $data);
+
+        self::assertNull($datas[3], 'StringPatternAnonymizer should keep null values');
+
+        self::assertCount(4, \array_unique($datas), 'All generated values are different.');
+    }
+}

--- a/tests/Unit/Anonymization/Anonymizer/Pattern/StringPatternTest.php
+++ b/tests/Unit/Anonymization/Anonymizer/Pattern/StringPatternTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MakinaCorpus\DbToolsBundle\Tests\Unit\Anonymization\Anonymizer\Pattern;
+
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Pattern\StringPattern;
+use PHPUnit\Framework\TestCase;
+
+class StringPatternTest extends TestCase
+{
+    private function serialize(array $parts): string
+    {
+        return \implode("\n", \array_map(fn ($part) => (string) $part, $parts));
+    }
+
+    public function testEscape(): void
+    {
+        $string = new StringPattern(
+            'Test [1-12] with {foo.bar} and [12-37] but [7;-12][3-6] is OK and {foo.bar:baz} is too, as {foo}, and {bla} also',
+            'some_pack',
+        );
+
+        // WARNING: Please keep whitespaces.
+        // See __toString() method on GeneratedPart implementations.
+        self::assertSame(
+            <<<EOT
+                "Test "
+                intrange:[1,12]
+                " with "
+                ref:{foo.bar:0}[0]
+                " and "
+                intrange:[12,37]
+                " but "
+                intrange:[-12,7]
+                intrange:[3,6]
+                " is OK and "
+                ref:{foo.bar:baz}[0]
+                " is too, as "
+                ref:{some_pack.foo:0}[0]
+                ", and "
+                ref:{some_pack.bla:0}[0]
+                " also"
+                EOT,
+            $this->serialize($string->parts),
+        );
+    }
+}


### PR DESCRIPTION
See documentation for more information.

TL;DR:

```yaml
anonymization:
    default:
        customer:
            biography:
                anonymizer: pattern
                options: {value: '{firstname} {lastname} lives in {address:locality} in {address:country}, he has [2,7] cats.'}
```

## String range

By adding `[MIN,MAX]` anywhere in your text, it will be replaced by a random integer
in the given range. For example `"I want [7-111] apples"`.

You can use negative integers such as `[-10,10]` or even a fully negative integer
range `[-127,-34]`.

## Single value from another anonymizer

By adding `{ANONYMIZER}` anywhere in your text, it will be replaced by a random value
given by the anonymizer. For example `"My email address is {email}, what's your ?"`.

## Column value from another anonymizer

By adding `{ANONYMIZER:COLUMN}` anywhere in your text, it will be replaced by a random
value for the named column given by the anonymizer. For example, `"The country I live into is {address:country}."`.

If you use more than one column of the same anonymizer in the same text value, the same
generated row from the target anonymizer will be used. For example, this text will give
a consistent result: `"The country I live in {address:locality} in {address:country}."`.
