### PR TITLE
no issue - introduce anonymizator Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 ## Next
 
 * [feature] 🌟 String pattern anonymizer, build complex strings by fetching values from other anonymizers.
+* [fix] Some minor PHP 8.4 deprecations.
+* [bc] Salt in `AbstractAnonymizer::$option->get('salt')` in now in `AbstractAnonymizer::$context->salt` (#235).
+* [bc] `AbstractAnonymizer::__construct()` now expects an additional `$context` parameter (#235).
+* [bc] `Anonymizator::__construct()` `$salt` parameter was removed (#235).
 * [bc] Officially drop support for MySQL 5.7 - code is still there and working but automated unit testing has been disabled.
+* [internal] introduce anonymizer context for carrying environment configuration to anonymizers (#235).
 * [internal] Add automated testing for MariaDB 12.
 * [internal] Rewrote `dev.sh` local unit testing script to be simpler, reorganized the local unit testing Docker stack.
 

--- a/src/Anonymization/Anonymizator.php
+++ b/src/Anonymization/Anonymizator.php
@@ -43,16 +43,16 @@ class Anonymizator implements LoggerAwareInterface
     ];
 
     private OutputInterface $output;
+    private readonly Context $defaultContext;
 
     public function __construct(
         private DatabaseSession $databaseSession,
         private AnonymizerRegistry $anonymizerRegistry,
         private AnonymizationConfig $anonymizationConfig,
-        private ?string $salt = null,
-        private readonly Context $defaultContext = new Context(),
     ) {
         $this->logger = new NullLogger();
         $this->output = new NullOutput();
+        $this->defaultContext = new Context();
     }
 
     /**
@@ -73,14 +73,10 @@ class Anonymizator implements LoggerAwareInterface
         return $this;
     }
 
+    #[\Deprecated(message: "Will be removed in 3.0, use Context::generateRandomSalt() instead.", since: "2.1.0")]
     public static function generateRandomSalt(): string
     {
-        return \base64_encode(\random_bytes(12));
-    }
-
-    protected function getSalt(): string
-    {
-        return $this->salt ??= self::generateRandomSalt();
+        return Context::generateRandomSalt();
     }
 
     /**
@@ -91,8 +87,7 @@ class Anonymizator implements LoggerAwareInterface
         return $this->anonymizerRegistry->createAnonymizer(
             $config->anonymizer,
             $config,
-            // @todo "salt" should belong to context instead.
-            $context->withOptions($config->options->with(['salt' => $this->getSalt()])),
+            $context,
             $this->databaseSession
         );
     }

--- a/src/Anonymization/Anonymizer/AbstractAnonymizer.php
+++ b/src/Anonymization/Anonymizer/AbstractAnonymizer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer;
 
-use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizator;
 use MakinaCorpus\QueryBuilder\DatabaseSession;
 use MakinaCorpus\QueryBuilder\Expression;
 use MakinaCorpus\QueryBuilder\ExpressionFactory;
@@ -18,30 +17,13 @@ abstract class AbstractAnonymizer
     public const JOIN_TABLE = '_target_table';
     public const TEMP_TABLE_PREFIX = '_db_tools_sample_';
 
-    /**
-     * @todo in 3.0 move this as a constructor-promoted property.
-     */
-    protected readonly Context $context;
-    protected readonly Options $options;
-
     final public function __construct(
         protected string $tableName,
         protected string $columnName,
         protected DatabaseSession $databaseSession,
-        /**
-         * @todo In 3.0, Options will be replaced with Context instead.
-         */
-        Options $options,
+        protected readonly Context $context,
+        protected readonly Options $options,
     ) {
-        if ($options instanceof Context) {
-            $this->context = $options;
-            $this->options = $options->options;
-        } else {
-            \trigger_deprecation('makinacorpus/db-tools-bundle', '2.1.0', \sprintf("%s::__construct() 'Options \$options' will be changed to 'Context \$context' in 3.0", static::class));
-            $this->options = $options;
-            $this->context = new Context($options);
-        }
-
         $this->validateOptions();
     }
 
@@ -90,14 +72,6 @@ abstract class AbstractAnonymizer
     protected function getJoinColumn(): Expression
     {
         return ExpressionFactory::column($this->getJoinId(), self::JOIN_TABLE);
-    }
-
-    /**
-     * Get a random, global salt for anonymizing hashed values.
-     */
-    protected function getSalt(): string
-    {
-        return $this->options->get('salt') ?? Anonymizator::generateRandomSalt();
     }
 
     /**

--- a/src/Anonymization/Anonymizer/AbstractAnonymizer.php
+++ b/src/Anonymization/Anonymizer/AbstractAnonymizer.php
@@ -18,12 +18,30 @@ abstract class AbstractAnonymizer
     public const JOIN_TABLE = '_target_table';
     public const TEMP_TABLE_PREFIX = '_db_tools_sample_';
 
+    /**
+     * @todo in 3.0 move this as a constructor-promoted property.
+     */
+    protected readonly Context $context;
+    protected readonly Options $options;
+
     final public function __construct(
         protected string $tableName,
         protected string $columnName,
         protected DatabaseSession $databaseSession,
-        protected Options $options,
+        /**
+         * @todo In 3.0, Options will be replaced with Context instead.
+         */
+        Options $options,
     ) {
+        if ($options instanceof Context) {
+            $this->context = $options;
+            $this->options = $options->options;
+        } else {
+            \trigger_deprecation('makinacorpus/db-tools-bundle', '2.1.0', \sprintf("%s::__construct() 'Options \$options' will be changed to 'Context \$context' in 3.0", static::class));
+            $this->options = $options;
+            $this->context = new Context($options);
+        }
+
         $this->validateOptions();
     }
 

--- a/src/Anonymization/Anonymizer/AnonymizerRegistry.php
+++ b/src/Anonymization/Anonymizer/AnonymizerRegistry.php
@@ -67,12 +67,12 @@ class AnonymizerRegistry
     public function createAnonymizer(
         string $name,
         AnonymizerConfig $config,
-        Options $options,
+        Context $context,
         DatabaseSession $databaseSession,
     ): AbstractAnonymizer {
         $className = $this->getAnonymizerClass($name);
 
-        $ret = new $className($config->table, $config->targetName, $databaseSession, $options);
+        $ret = new $className($config->table, $config->targetName, $databaseSession, $context, $config->options);
         \assert($ret instanceof AbstractAnonymizer);
 
         if ($ret instanceof WithAnonymizerRegistry) {

--- a/src/Anonymization/Anonymizer/Context.php
+++ b/src/Anonymization/Anonymizer/Context.php
@@ -4,108 +4,18 @@ declare(strict_types=1);
 
 namespace MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer;
 
-/**
- * @todo
- *   Remove "extends Options" in 3.0. Change AbstractAnonymizer::__construct() signature accordingly.
- */
-class Context extends Options
+class Context
 {
+    public readonly string $salt;
+
     public function __construct(
-        public Options $options = new Options(),
-    ) {}
-
-    public function withOptions(Options $options): Context
-    {
-        return new self($options);
+        ?string $salt = null,
+    ) {
+        $this->salt = $salt ?? self::generateRandomSalt();
     }
 
-    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
-    private function throwOptionsDeprecation(string $method): never
+    public static function generateRandomSalt(): string
     {
-        throw new \LogicException(\sprintf("Calling %s::%s() is forbidden, this method only exists for backward compatibility purpose..", static::class, $method));
-    }
-
-    #[\Override]
-    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
-    public function has(string $name): bool
-    {
-        $this->throwOptionsDeprecation(__METHOD__);
-    }
-
-    #[\Override]
-    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
-    public function get(string $name, mixed $default = null, bool $required = false): mixed
-    {
-        $this->throwOptionsDeprecation(__METHOD__);
-    }
-
-    #[\Override]
-    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
-    public function all(): array
-    {
-        $this->throwOptionsDeprecation(__METHOD__);
-    }
-
-    #[\Override]
-    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
-    public function count(): int
-    {
-        $this->throwOptionsDeprecation(__METHOD__);
-    }
-
-    #[\Override]
-    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
-    public function with(array $options): Options
-    {
-        $this->throwOptionsDeprecation(__METHOD__);
-    }
-
-    #[\Override]
-    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
-    public function toDisplayString(): string
-    {
-        $this->throwOptionsDeprecation(__METHOD__);
-    }
-
-    #[\Override]
-    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
-    public function getString(string $name, ?string $default = null, bool $required = false): ?string
-    {
-        $this->throwOptionsDeprecation(__METHOD__);
-    }
-
-    #[\Override]
-    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
-    public function getBool(string $name, ?bool $default = null, bool $required = false): ?bool
-    {
-        $this->throwOptionsDeprecation(__METHOD__);
-    }
-
-    #[\Override]
-    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
-    public function getInt(string $name, ?int $default = null, bool $required = false): ?int
-    {
-        $this->throwOptionsDeprecation(__METHOD__);
-    }
-
-    #[\Override]
-    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
-    public function getFloat(string $name, ?float $default = null, bool $required = false): ?float
-    {
-        $this->throwOptionsDeprecation(__METHOD__);
-    }
-
-    #[\Override]
-    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
-    public function getDate(string $name, ?\DateTimeImmutable $default = null, bool $required = false): ?\DateTimeImmutable
-    {
-        $this->throwOptionsDeprecation(__METHOD__);
-    }
-
-    #[\Override]
-    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
-    public function getInterval(string $name, ?\DateInterval $default = null, bool $required = false): ?\DateInterval
-    {
-        $this->throwOptionsDeprecation(__METHOD__);
+        return \base64_encode(\random_bytes(12));
     }
 }

--- a/src/Anonymization/Anonymizer/Context.php
+++ b/src/Anonymization/Anonymizer/Context.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer;
+
+/**
+ * @todo
+ *   Remove "extends Options" in 3.0. Change AbstractAnonymizer::__construct() signature accordingly.
+ */
+class Context extends Options
+{
+    public function __construct(
+        public Options $options = new Options(),
+    ) {}
+
+    public function withOptions(Options $options): Context
+    {
+        return new self($options);
+    }
+
+    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
+    private function throwOptionsDeprecation(string $method): never
+    {
+        throw new \LogicException(\sprintf("Calling %s::%s() is forbidden, this method only exists for backward compatibility purpose..", static::class, $method));
+    }
+
+    #[\Override]
+    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
+    public function has(string $name): bool
+    {
+        $this->throwOptionsDeprecation(__METHOD__);
+    }
+
+    #[\Override]
+    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
+    public function get(string $name, mixed $default = null, bool $required = false): mixed
+    {
+        $this->throwOptionsDeprecation(__METHOD__);
+    }
+
+    #[\Override]
+    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
+    public function all(): array
+    {
+        $this->throwOptionsDeprecation(__METHOD__);
+    }
+
+    #[\Override]
+    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
+    public function count(): int
+    {
+        $this->throwOptionsDeprecation(__METHOD__);
+    }
+
+    #[\Override]
+    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
+    public function with(array $options): Options
+    {
+        $this->throwOptionsDeprecation(__METHOD__);
+    }
+
+    #[\Override]
+    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
+    public function toDisplayString(): string
+    {
+        $this->throwOptionsDeprecation(__METHOD__);
+    }
+
+    #[\Override]
+    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
+    public function getString(string $name, ?string $default = null, bool $required = false): ?string
+    {
+        $this->throwOptionsDeprecation(__METHOD__);
+    }
+
+    #[\Override]
+    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
+    public function getBool(string $name, ?bool $default = null, bool $required = false): ?bool
+    {
+        $this->throwOptionsDeprecation(__METHOD__);
+    }
+
+    #[\Override]
+    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
+    public function getInt(string $name, ?int $default = null, bool $required = false): ?int
+    {
+        $this->throwOptionsDeprecation(__METHOD__);
+    }
+
+    #[\Override]
+    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
+    public function getFloat(string $name, ?float $default = null, bool $required = false): ?float
+    {
+        $this->throwOptionsDeprecation(__METHOD__);
+    }
+
+    #[\Override]
+    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
+    public function getDate(string $name, ?\DateTimeImmutable $default = null, bool $required = false): ?\DateTimeImmutable
+    {
+        $this->throwOptionsDeprecation(__METHOD__);
+    }
+
+    #[\Override]
+    #[\Deprecated(message: "Only exists for class signature backward compatibility.", since: "2.1.0")]
+    public function getInterval(string $name, ?\DateInterval $default = null, bool $required = false): ?\DateInterval
+    {
+        $this->throwOptionsDeprecation(__METHOD__);
+    }
+}

--- a/src/Anonymization/Anonymizer/Core/EmailAnonymizer.php
+++ b/src/Anonymization/Anonymizer/Core/EmailAnonymizer.php
@@ -38,7 +38,7 @@ class EmailAnonymizer extends AbstractSingleColumnAnonymizer
             $userExpr = $expr->column($this->columnName, $this->tableName);
 
             if ($this->options->getBool('use_salt', true)) {
-                $userExpr = $expr->concat($userExpr, $expr->value($this->getSalt()));
+                $userExpr = $expr->concat($userExpr, $expr->value($this->context->salt));
             }
 
             $emailHashExpr = $expr->md5($userExpr);

--- a/src/Anonymization/Anonymizer/Core/Md5Anonymizer.php
+++ b/src/Anonymization/Anonymizer/Core/Md5Anonymizer.php
@@ -27,7 +27,7 @@ class Md5Anonymizer extends AbstractSingleColumnAnonymizer
         $columnExpr = $expr->column($this->columnName, $this->tableName);
 
         if ($this->options->get('use_salt', true)) {
-            $columnExpr = $expr->concat($columnExpr, $expr->value($this->getSalt()));
+            $columnExpr = $expr->concat($columnExpr, $expr->value($this->context->salt));
 
             // Work around some RDBMS not seeing the NULL value anymore
             // once we added the string concat.

--- a/src/Anonymization/Anonymizer/Core/StringPatternAnonymizer.php
+++ b/src/Anonymization/Anonymizer/Core/StringPatternAnonymizer.php
@@ -194,14 +194,14 @@ class StringPatternAnonymizer extends AbstractSingleColumnAnonymizer implements 
             return $ret;
         }
 
-        $config = new AnonymizerConfig($this->tableName, $this->columnName, $anonymizer, new Options());
+        $config = new AnonymizerConfig($this->tableName, $this->columnName, $anonymizer, $options ?? new Options());
 
         return $this->childAnonymizers[$key] = $this
             ->getAnonymizerRegistry()
             ->createAnonymizer(
                 $anonymizer,
                 $config,
-                $options ?? new Options(),
+                $this->context,
                 $this->databaseSession
             )
         ;

--- a/tests/Unit/Anonymization/Anonymizer/AbstractMultipleColumnAnonymizerTest.php
+++ b/tests/Unit/Anonymization/Anonymizer/AbstractMultipleColumnAnonymizerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MakinaCorpus\DbToolsBundle\Tests\Unit\Anonymization\Anonymizer;
 
 use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\AbstractMultipleColumnAnonymizer;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Context;
 use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Options;
 use MakinaCorpus\DbToolsBundle\Attribute\AsAnonymizer;
 use MakinaCorpus\DbToolsBundle\Test\UnitTestCase;
@@ -17,6 +18,7 @@ class AbstractMultipleColumnAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'column_1' => 'actual_column_1',
                 'column_2' => 'actual_column_2',
@@ -32,6 +34,7 @@ class AbstractMultipleColumnAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'column_2' => 'actual_column_2',
             ]),
@@ -48,7 +51,8 @@ class AbstractMultipleColumnAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
-            new Options([]),
+            new Context(),
+            new Options(),
         );
     }
 
@@ -60,6 +64,7 @@ class AbstractMultipleColumnAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'column_1' => 'actual_column_1',
                 'column_2' => 'actual_column_1',

--- a/tests/Unit/Anonymization/Anonymizer/Core/ConstantAnonymizerTest.php
+++ b/tests/Unit/Anonymization/Anonymizer/Core/ConstantAnonymizerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MakinaCorpus\DbToolsBundle\Tests\Unit\Anonymization\Anonymizer\Core;
 
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Context;
 use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Core\ConstantAnonymizer;
 use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Options;
 use MakinaCorpus\DbToolsBundle\Test\UnitTestCase;
@@ -16,6 +17,7 @@ class ConstantAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'value' => 'test',
             ]),
@@ -32,6 +34,7 @@ class ConstantAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([]),
         );
     }

--- a/tests/Unit/Anonymization/Anonymizer/Core/EmailAnonymizerTest.php
+++ b/tests/Unit/Anonymization/Anonymizer/Core/EmailAnonymizerTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace MakinaCorpus\DbToolsBundle\Tests\Unit\Anonymization\Anonymizer\Core;
 
-use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Options;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Context;
 use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Core\EmailAnonymizer;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Options;
 use MakinaCorpus\DbToolsBundle\Test\UnitTestCase;
 
 class EmailAnonymizerTest extends UnitTestCase
@@ -16,7 +17,8 @@ class EmailAnonymizerTest extends UnitTestCase
             'some_table',
             'email',
             $this->getDatabaseSession(),
-            new Options([]),
+            new Context(),
+            new Options(),
         );
 
         self::expectNotToPerformAssertions();
@@ -28,6 +30,7 @@ class EmailAnonymizerTest extends UnitTestCase
             'some_table',
             'email',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'domain' => 'makina-corpus.com',
             ]),
@@ -44,6 +47,7 @@ class EmailAnonymizerTest extends UnitTestCase
             'some_table',
             'email',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'domain' => ['ttt', 'ttt'],
             ]),
@@ -56,6 +60,7 @@ class EmailAnonymizerTest extends UnitTestCase
             'some_table',
             'email',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'use_salt' => true,
             ]),
@@ -72,6 +77,7 @@ class EmailAnonymizerTest extends UnitTestCase
             'some_table',
             'email',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'use_salt' => ['true'],
             ]),
@@ -86,9 +92,10 @@ class EmailAnonymizerTest extends UnitTestCase
             'some_table',
             'email',
             $this->getDatabaseSession(),
-            new Options([
-                'salt' => 'my_salt',
-            ])
+            new Context(
+                salt: 'my_salt',
+            ),
+            new Options(),
         );
 
         $instance->anonymize($update);
@@ -121,9 +128,11 @@ class EmailAnonymizerTest extends UnitTestCase
             'some_table',
             'email',
             $this->getDatabaseSession(),
+            new Context(
+                salt: 'my_salt',
+            ),
             new Options([
                 'domain' => 'makina-corpus.com',
-                'salt' => 'my_salt',
             ]),
         );
 
@@ -157,6 +166,7 @@ class EmailAnonymizerTest extends UnitTestCase
             'some_table',
             'email',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'use_salt' => false,
             ]),

--- a/tests/Unit/Anonymization/Anonymizer/Core/FloatAnonymizerTest.php
+++ b/tests/Unit/Anonymization/Anonymizer/Core/FloatAnonymizerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MakinaCorpus\DbToolsBundle\Tests\Unit\Anonymization\Anonymizer\Core;
 
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Context;
 use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Core\FloatAnonymizer;
 use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Options;
 use MakinaCorpus\DbToolsBundle\Test\UnitTestCase;
@@ -16,6 +17,7 @@ class FloatAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'min' => 12.5,
                 'max' => 14.5,
@@ -33,6 +35,7 @@ class FloatAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'min' => 15.5,
                 'max' => 14.5,
@@ -46,6 +49,7 @@ class FloatAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'delta' => 12.5,
             ]),
@@ -62,6 +66,7 @@ class FloatAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'delta' => -12.5,
             ]),
@@ -74,6 +79,7 @@ class FloatAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'percent' => 12,
             ]),
@@ -90,6 +96,7 @@ class FloatAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'percent' => -12,
             ]),
@@ -104,6 +111,7 @@ class FloatAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'min' => 12.5,
                 'max' => 14.5,
@@ -117,6 +125,7 @@ class FloatAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'min' => 12.5,
                 'max' => 14.5,
@@ -130,6 +139,7 @@ class FloatAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'delta' => 14.5,
                 'percent' => 14.5,
@@ -145,7 +155,8 @@ class FloatAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
-            new Options([]),
+            new Context(),
+            new Options(),
         );
     }
 }

--- a/tests/Unit/Anonymization/Anonymizer/Core/IbanBicAnonymizerTest.php
+++ b/tests/Unit/Anonymization/Anonymizer/Core/IbanBicAnonymizerTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace MakinaCorpus\DbToolsBundle\Tests\Unit\Anonymization\Anonymizer\Core;
 
-use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Options;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Context;
 use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Core\IbanBicAnonymizer;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Options;
 use MakinaCorpus\DbToolsBundle\Test\UnitTestCase;
 
 class IbanBicAnonymizerTest extends UnitTestCase
@@ -16,6 +17,7 @@ class IbanBicAnonymizerTest extends UnitTestCase
             'some_table',
             'iban',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'iban' => 'foo_iban',
                 'bic' => 'foo_bic',
@@ -31,6 +33,7 @@ class IbanBicAnonymizerTest extends UnitTestCase
             'some_table',
             'iban',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'iban' => 'foo_iban',
                 'bic' => 'foo_bic',
@@ -50,6 +53,7 @@ class IbanBicAnonymizerTest extends UnitTestCase
             'some_table',
             'iban',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'iban' => 'foo_iban',
                 'bic' => 'foo_bic',
@@ -66,6 +70,7 @@ class IbanBicAnonymizerTest extends UnitTestCase
             'some_table',
             'iban',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'iban' => 'foo_iban',
                 'bic' => 'foo_bic',
@@ -82,6 +87,7 @@ class IbanBicAnonymizerTest extends UnitTestCase
             'some_table',
             'iban',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'iban' => 'foo_iban',
                 'bic' => 'foo_bic',
@@ -98,6 +104,7 @@ class IbanBicAnonymizerTest extends UnitTestCase
             'some_table',
             'iban',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'iban' => 'foo_iban',
                 'bic' => 'foo_bic',
@@ -114,6 +121,7 @@ class IbanBicAnonymizerTest extends UnitTestCase
             'some_table',
             'iban',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'iban' => 'foo_iban',
                 'bic' => 'foo_bic',

--- a/tests/Unit/Anonymization/Anonymizer/Core/IntegerAnonymizerTest.php
+++ b/tests/Unit/Anonymization/Anonymizer/Core/IntegerAnonymizerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MakinaCorpus\DbToolsBundle\Tests\Unit\Anonymization\Anonymizer\Core;
 
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Context;
 use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Core\IntegerAnonymizer;
 use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Options;
 use MakinaCorpus\DbToolsBundle\Test\UnitTestCase;
@@ -16,6 +17,7 @@ class IntegerAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'min' => 12,
                 'max' => 14,
@@ -33,6 +35,7 @@ class IntegerAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'min' => 15,
                 'max' => 14,
@@ -46,6 +49,7 @@ class IntegerAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'delta' => 12,
             ]),
@@ -62,6 +66,7 @@ class IntegerAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'delta' => -12,
             ]),
@@ -74,6 +79,7 @@ class IntegerAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'percent' => 12,
             ]),
@@ -90,6 +96,7 @@ class IntegerAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'percent' => -12,
             ]),
@@ -104,6 +111,7 @@ class IntegerAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'min' => 12,
                 'max' => 14,
@@ -117,6 +125,7 @@ class IntegerAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'min' => 12,
                 'max' => 14,
@@ -130,6 +139,7 @@ class IntegerAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'delta' => 14,
                 'percent' => 14,
@@ -145,7 +155,8 @@ class IntegerAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
-            new Options([]),
+            new Context(),
+            new Options(),
         );
     }
 }

--- a/tests/Unit/Anonymization/Anonymizer/Core/LoremIpsumAnonymizerTest.php
+++ b/tests/Unit/Anonymization/Anonymizer/Core/LoremIpsumAnonymizerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MakinaCorpus\DbToolsBundle\Tests\Unit\Anonymization\Anonymizer\Core;
 
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Context;
 use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Core\LoremIpsumAnonymizer;
 use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Options;
 use MakinaCorpus\DbToolsBundle\Test\UnitTestCase;
@@ -16,7 +17,8 @@ class LoremIpsumAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
-            new Options([]),
+            new Context(),
+            new Options(),
         );
 
         self::expectNotToPerformAssertions();
@@ -28,6 +30,7 @@ class LoremIpsumAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'words' => 15,
             ]),
@@ -44,6 +47,7 @@ class LoremIpsumAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'words' => -15,
             ]),
@@ -56,6 +60,7 @@ class LoremIpsumAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'paragraphs' => 15,
             ]),
@@ -72,6 +77,7 @@ class LoremIpsumAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'paragraphs' => -15,
             ]),

--- a/tests/Unit/Anonymization/Anonymizer/Core/Md5AnonymizerTest.php
+++ b/tests/Unit/Anonymization/Anonymizer/Core/Md5AnonymizerTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace MakinaCorpus\DbToolsBundle\Tests\Unit\Anonymization\Anonymizer\Core;
 
-use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Options;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Context;
 use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Core\Md5Anonymizer;
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Options;
 use MakinaCorpus\DbToolsBundle\Test\UnitTestCase;
 
 class Md5AnonymizerTest extends UnitTestCase
@@ -18,9 +19,8 @@ class Md5AnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
-            new Options([
-                'salt' => 'my_salt',
-            ])
+            new Context(salt: 'my_salt'),
+            new Options(),
         );
 
         $instance->anonymize($update);
@@ -54,6 +54,7 @@ class Md5AnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'use_salt' => false,
             ])

--- a/tests/Unit/Anonymization/Anonymizer/Core/PasswordAnonymizerTest.php
+++ b/tests/Unit/Anonymization/Anonymizer/Core/PasswordAnonymizerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MakinaCorpus\DbToolsBundle\Tests\Unit\Anonymization\Anonymizer\Core;
 
+use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Context;
 use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Core\PasswordAnonymizer;
 use MakinaCorpus\DbToolsBundle\Anonymization\Anonymizer\Options;
 use MakinaCorpus\DbToolsBundle\Test\UnitTestCase;
@@ -16,7 +17,8 @@ class PasswordAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
-            new Options([]),
+            new Context(),
+            new Options(),
         );
 
         self::expectNotToPerformAssertions();
@@ -28,6 +30,7 @@ class PasswordAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'password' => 'test',
             ]),
@@ -42,6 +45,7 @@ class PasswordAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'algorithm' => 'bcrypt',
             ]),
@@ -58,6 +62,7 @@ class PasswordAnonymizerTest extends UnitTestCase
             'some_table',
             'some_column',
             $this->getDatabaseSession(),
+            new Context(),
             new Options([
                 'algorithm' => 'toto',
             ]),


### PR DESCRIPTION
In many occasions, we need to share context for a single anonyzation run between anonymizers:
 - Global "salt" option, for hashing (actual).
 - Global "base_path" option introduced in #228 (not merged yet) for file loading.
 - Future sample table list (in order to avoid creating and populating the same table many times when the same anonymizer with a fixed list is used more than once).
 - And probably more in the future.

All this data must go directly to anonymizers, but using the `Options` instance is wrong:
 - Even if we propagate some data into it, it is not shared (so goodbye sample table sharing).
 - Adding more and more options into it makes anonymizers unable to use those options names for themselves.

The less impactful solution I found is the following:
1. Create a new `Context` class, which will carry all this information.
2. Change constructor of `AbstractAnonymizer` in order to accept this new parameter.

But we have a problem here, it's BC break, and a huge one, it will cause a refactor of all our tests, and possibly create problems with existing custom anonymizers in the wild (I guess there's not much, but you never know). This can be mitigated by the fact that people should extend our abstract implementations and probably won't override the constructor, but you never know, it's public API now.

So, temporary ulgy solution:

1. Make `Context` extend `Options` (even if it makes no sense) and pass it to `AbstractAnonymizer::__construct()`: no signature change needed.
2. Adapt `AbstractAnonymizer::__construct()` to check validity of input, and create a dummy `Context` instance when `Options` are passed instead.
3. Deprecate this signature and change it in 3.0 to pass two parameters: `Options $options` and `Context $context` (which will not extend `Options` anymore).