### PR TITLE
feat: allow symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "doctrine/dbal": "<3.0|>=5.0",
         "doctrine/orm": "<2.15|>=4.0",
         "seld/phar-utils": "<1.2|>=2.0",
-        "symfony/password-hasher": "<6.0|>=8.0"
+        "symfony/password-hasher": "<6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,25 +15,25 @@
         "php": ">=8.1",
         "makinacorpus/query-builder": "^1.6.2",
         "psr/log": "^3.0",
-        "symfony/config": "^6.0|^7.0",
-        "symfony/console": "^6.0|^7.0",
-        "symfony/filesystem": "^6.0|^7.0",
-        "symfony/finder": "^6.0|^7.0",
-        "symfony/options-resolver": "^6.0|^7.0",
-        "symfony/process": "^6.0|^7.0",
-        "symfony/yaml": "^6.0|^7.0"
+        "symfony/config": "^6.0|^7.0|^8.0",
+        "symfony/console": "^6.0|^7.0|^8.0",
+        "symfony/filesystem": "^6.0|^7.0|^8.0",
+        "symfony/finder": "^6.0|^7.0|^8.0",
+        "symfony/options-resolver": "^6.0|^7.0|^8.0",
+        "symfony/process": "^6.0|^7.0|^8.0",
+        "symfony/yaml": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "doctrine/doctrine-bundle": "^2.10.0",
+        "doctrine/doctrine-bundle": "^2.10.0|^3.0",
         "doctrine/orm": "^2.15|^3.0",
         "friendsofphp/php-cs-fixer": "^3.34",
-        "laravel/framework": "^10.0|^11.0",
+        "laravel/framework": "^10.0|^11.0|^12.0|13.0.x-dev",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^10.4",
-        "symfony/dependency-injection": "^6.0|^7.0",
-        "symfony/framework-bundle": "^6.0|^7.0",
-        "symfony/password-hasher": "^6.0|^7.0",
-        "symfony/validator": "^6.3|^7.0"
+        "symfony/dependency-injection": "^6.0|^7.0|^8.0",
+        "symfony/framework-bundle": "^6.0|^7.0|^8.0",
+        "symfony/password-hasher": "^6.0|^7.0|^8.0",
+        "symfony/validator": "^6.3|^7.0|^8.0"
     },
     "suggest": {
         "db-tools-bundle/pack-faker": "FakerPHP/Faker bridge anonyzer pack",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "doctrine/doctrine-bundle": "^2.10.0|^3.0",
         "doctrine/orm": "^2.15|^3.0",
         "friendsofphp/php-cs-fixer": "^3.34",
-        "laravel/framework": "^10.0|^11.0|^12.0|13.0.x-dev",
+        "laravel/framework": "^10.0|^11.0|^12.0|^13.0",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^10.4",
         "symfony/dependency-injection": "^6.0|^7.0|^8.0",

--- a/src/Test/TestKernel.php
+++ b/src/Test/TestKernel.php
@@ -42,7 +42,7 @@ class TestKernel extends Kernel implements CompilerPassInterface
         ];
     }
 
-    protected function configureContainer(ContainerBuilder $containerBuilder, LoaderInterface $loader)
+    protected function configureContainer(ContainerBuilder $containerBuilder, LoaderInterface $loader): void
     {
         $containerBuilder->loadFromExtension('framework', [
             'secret' => 123,
@@ -69,5 +69,5 @@ class TestKernel extends Kernel implements CompilerPassInterface
     }
 
     #[\Override]
-    public function process(ContainerBuilder $container) {}
+    public function process(ContainerBuilder $container): void {}
 }


### PR DESCRIPTION
allow laravel/framework > 11
13.0.x-dev needs to be reverted after a stable release is available.

https://github.com/makinacorpus/DbToolsBundle/issues/242

I would suggest to bump `^6.0|^7.0|^8.0` to `^6.4|^7.0|^8.0` if maintainers agree.


removed symfony/password-hasher but this needs a closer look
@pounard maybe you can have a look if this conflict can be removed.
https://github.com/makinacorpus/DbToolsBundle/pull/152/files#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R45