### PR TITLE
Introduce a new "connection provider" for standalone usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+* [feature] 🌟 Experimental `ConnectionProvider` for standalone usage where fetching the database connection DSN is delegated to user custom code (#245).
 * [feature] 🌟 String pattern anonymizer, build complex strings by fetching values from other anonymizers.
 * [bc] Officially drop support for MySQL 5.7 - code is still there and working but automated unit testing has been disabled.
 * [internal] Add automated testing for MariaDB 12.

--- a/docs/content/configuration/connection_provider.md
+++ b/docs/content/configuration/connection_provider.md
@@ -1,0 +1,204 @@
+# Standalone connection provider
+
+When dealing with edge case environement where a static database URL cannot
+work, the *connection provider* feature may help you.
+
+Basic idea is to delegate the database connection URL string to a custom function.
+
+:::warning
+This feature is experimental and API is subject to change in the future.
+:::
+
+## Basic example
+
+Use case: you are working in a multi-tenant environment, each client database
+has the same database schema, but has different database credentials.
+
+Let's consider you already have a central component you can access using PHP code
+which allows you to find a client database connection:
+
+```php
+namespace MyApp;
+
+class MyClientInstanceRegistry
+{
+    public static function getDatabaseCredentialsForClient(string $id): array;
+}
+```
+
+We are making this example simple for educational purpose, but in real life
+use cases you probably will have a more complex component initialization process
+for this.
+
+And you have the following anonymization configuration:
+
+```yaml
+connections:
+    any_client: pgsql://clientid:clientpassword@somehostname/client1
+
+anonymization:
+    any_client:
+        users:
+            lastname: fr-fr.lastname
+```
+
+Your main obstacle here is to give the correct database URL for the client you
+with to act upon. Let's consider that your solution is to use an environment
+variable for acting upon each database independently, such as:
+
+```sh
+CLIENT_ID="client1" vendor/bin/db-tools anonymize
+```
+
+Following chapter will guide you throught three different methods to achieve this.
+
+## Implementing the connection provider interface
+
+You can implement the `ConnectionProvider` interface as such:
+
+```php
+namespace MyApp\DbToolsBundle;
+
+use MakinaCorpus\DbToolsBundle\Bridge\Standalone\ConnectionProvider;
+
+class MyClientConnectionProvider implements ConnectionProvider
+{
+    #[\Override]
+    public function createConnectionDsn(string $name): string
+    {
+        if (!$clientId = getenv('CLIENT_ID')) {
+            throw new \RuntimeException("Did you forget to set the CLIENT_ID environment variable?");
+        }
+
+        $credentials = MyClientInstanceRegistry::getDatabaseCredentialsForClient($clientId);
+
+        return \sprintf(
+            'pgsql://%s:%s@%s:%d/%s?some_option=some_value',
+            \rawurlencode($credentials['username']),
+            \rawurlencode($credentials['password']),
+            \rawurlencode($credentials['hostname']),
+            $credentials['port'],
+            \rawurlencode($credentials['database']),
+        );
+    }
+}
+```
+
+Then adapt your YAML configuration:
+
+```yaml
+connections:
+    any_client: MyApp\DbToolsBundle\MyClientConnectionProvider
+```
+
+## Using an invokable class
+
+You otherwise simply can write any class implenting the `__invoke()` method:
+
+```php
+namespace MyApp\DbToolsBundle;
+
+class MyInvokableClientConnectionProvider
+{
+    public function __invoke()
+    {
+        if (!$clientId = getenv('CLIENT_ID')) {
+            throw new \RuntimeException("Did you forget to set the CLIENT_ID environment variable?");
+        }
+
+        $credentials = MyClientInstanceRegistry::getDatabaseCredentialsForClient($clientId);
+
+        return \sprintf(
+            'pgsql://%s:%s@%s:%d/%s?some_option=some_value',
+            \rawurlencode($credentials['username']),
+            \rawurlencode($credentials['password']),
+            \rawurlencode($credentials['hostname']),
+            $credentials['port'],
+            \rawurlencode($credentials['database']),
+        );
+    }
+}
+```
+
+Then adapt your YAML configuration:
+
+```yaml
+connections:
+    any_client: MyApp\DbToolsBundle\MyInvokableClientConnectionProvider
+```
+
+## Using a class static method
+
+You can use an object static method:
+
+```php
+namespace MyApp\SomeNamespace;
+
+class SomeExistingClass
+{
+    // ... your other code (or not).
+
+    public static function myDbToolsConnectionProvider()
+    {
+        if (!$clientId = getenv('CLIENT_ID')) {
+            throw new \RuntimeException("Did you forget to set the CLIENT_ID environment variable?");
+        }
+
+        $credentials = MyClientInstanceRegistry::getDatabaseCredentialsForClient($clientId);
+
+        return \sprintf(
+            'pgsql://%s:%s@%s:%d/%s?some_option=some_value',
+            \rawurlencode($credentials['username']),
+            \rawurlencode($credentials['password']),
+            \rawurlencode($credentials['hostname']),
+            $credentials['port'],
+            \rawurlencode($credentials['database']),
+        );
+    }
+}
+```
+
+Then adapt your YAML configuration:
+
+```yaml
+connections:
+    any_client: MyApp\SomeNamespace\SomeExistingClass::myDbToolsConnectionProvider
+```
+
+## Using an arbitrary function
+
+Or simply use any PHP function which was loaded using the autoloader:
+
+```php
+function my_dbtools_client_connection_provider(): string
+{
+    if (!$clientId = getenv('CLIENT_ID')) {
+        throw new \RuntimeException("Did you forget to set the CLIENT_ID environment variable?");
+    }
+
+    $credentials = MyClientInstanceRegistry::getDatabaseCredentialsForClient($clientId);
+
+    return \sprintf(
+        'pgsql://%s:%s@%s:%d/%s?some_option=some_value',
+        \rawurlencode($credentials['username']),
+        \rawurlencode($credentials['password']),
+        \rawurlencode($credentials['hostname']),
+        $credentials['port'],
+        \rawurlencode($credentials['database']),
+    );
+}
+```
+
+Then adapt your YAML configuration:
+
+```yaml
+connections:
+    any_client: my_dbtools_client_connection_provider
+```
+
+## Notes
+
+In all cases, the method signature function is always the same `connection_provider(string $name): string`.
+
+You may omit the `$name` parameter if you don't intend to use it. It contains
+the connection name as specified in the YAML configuration `connections` value.

--- a/docs/content/configuration/reference.md
+++ b/docs/content/configuration/reference.md
@@ -434,6 +434,13 @@ connections: "pgsql://username:password@hostname:port/database?version=16.0&othe
 If you configure this parameter with a single URL string with no connection name,
 the connection name will be `default`.
 :::
+
+:::tip
+If you cannot write a static database connection URL, the standalone configuration
+file allows you to delegate the connection URL creation to a PHP function.
+
+See [standalone connection provider documentation](./connection_provider) for more information.
+:::
 @@@
 
 :::tip

--- a/src/Bridge/Standalone/ConnectionProvider.php
+++ b/src/Bridge/Standalone/ConnectionProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MakinaCorpus\DbToolsBundle\Bridge\Standalone;
+
+/**
+ * Allow user to plug into the database session creation.
+ *
+ * This is intented for edge cases, such as multi-tenant architectures for
+ * example where you would like to be able to change the database URL using
+ * environment variables for example.
+ *
+ * As of now, this is intended to use in standalone flavor only, in most
+ * cases when integrating with a framework such as Symfony or Laravel, the
+ * framework will fully handle the database connections by itself.
+ *
+ * @experimental
+ */
+interface ConnectionProvider
+{
+    /**
+     * Dynamically create the database DSN, such as:
+     *   "pgsql://username:password@hostname:port/database?version=16.0"
+     *
+     * If you handle a single connection using your implementation, you may
+     * skip entirely using the $name parameter and simply return the DSN.
+     *
+     * If you manage more than one connection and $name is erroneous or
+     * unknown, you are free to raise any exception, this will force the
+     * process to stop.
+     */
+    public function createConnectionDsn(string $name): string;
+}

--- a/tests/Mock/ConnectionProviderInvokable.php
+++ b/tests/Mock/ConnectionProviderInvokable.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MakinaCorpus\DbToolsBundle\Tests\Mock;
+
+class ConnectionProviderInvokable
+{
+    public function __invoke()
+    {
+        return 'vendor://user1:pass1@host1:2345/db1?opt1=val1';
+    }
+}

--- a/tests/Mock/ConnectionProviderNormal.php
+++ b/tests/Mock/ConnectionProviderNormal.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MakinaCorpus\DbToolsBundle\Tests\Mock;
+
+use MakinaCorpus\DbToolsBundle\Bridge\Standalone\ConnectionProvider;
+
+class ConnectionProviderNormal implements ConnectionProvider
+{
+    #[\Override]
+    public function createConnectionDsn(string $name): string
+    {
+        return 'vendor://user3:pass3@host3:2345/db3?opt3=' . $name;
+    }
+}

--- a/tests/Mock/ConnectionProviderStatic.php
+++ b/tests/Mock/ConnectionProviderStatic.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MakinaCorpus\DbToolsBundle\Tests\Mock;
+
+class ConnectionProviderStatic
+{
+    public static function createConnectionDsn(string $name): string
+    {
+        return 'vendor://user5:pass5@host5:2345/db5?opt5=' . $name;
+    }
+}

--- a/tests/Unit/Bridge/Standalone/ConnectionProviderTest.php
+++ b/tests/Unit/Bridge/Standalone/ConnectionProviderTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MakinaCorpus\DbToolsBundle\Tests\Unit\Bridge\Symfony\DependencyInjection;
+
+use MakinaCorpus\DbToolsBundle\Bridge\Standalone\StandaloneDatabaseSessionRegistry;
+use MakinaCorpus\DbToolsBundle\Error\ConfigurationException;
+use MakinaCorpus\DbToolsBundle\Tests\Mock\ConnectionProviderInvokable;
+use MakinaCorpus\DbToolsBundle\Tests\Mock\ConnectionProviderNormal;
+use PHPUnit\Framework\TestCase;
+use MakinaCorpus\DbToolsBundle\Tests\Mock\ConnectionProviderStatic;
+
+class ConnectionProviderTest extends TestCase
+{
+    public function testWithConnectionProvider(): void
+    {
+        $databaseSessionRegistry = new StandaloneDatabaseSessionRegistry([
+            'default' => ConnectionProviderNormal::class,
+        ]);
+
+        $dsn = $databaseSessionRegistry->getConnectionDsn('default');
+
+        self::assertSame(
+            'any-vendor://user3:pass3@host3:2345/db3?opt3=default',
+            $dsn->toUrl(),
+        );
+    }
+
+    public function testWithInvokable(): void
+    {
+        $databaseSessionRegistry = new StandaloneDatabaseSessionRegistry([
+            'default' => ConnectionProviderInvokable::class,
+        ]);
+
+        $dsn = $databaseSessionRegistry->getConnectionDsn('default');
+
+        self::assertSame(
+            'any-vendor://user1:pass1@host1:2345/db1?opt1=val1',
+            $dsn->toUrl(),
+        );
+    }
+
+    public function testWithStaticMethod(): void
+    {
+        $databaseSessionRegistry = new StandaloneDatabaseSessionRegistry([
+            'default' => ConnectionProviderStatic::class . '::createConnectionDsn',
+        ]);
+
+        $dsn = $databaseSessionRegistry->getConnectionDsn('default');
+
+        self::assertSame(
+            'any-vendor://user5:pass5@host5:2345/db5?opt5=default',
+            $dsn->toUrl(),
+        );
+    }
+
+    public function testWithFunction(): void
+    {
+        $databaseSessionRegistry = new StandaloneDatabaseSessionRegistry([
+            'default' => '\\MakinaCorpus\\DbToolsBundle\\Tests\\Unit\\Bridge\\Symfony\\DependencyInjection\\connection_provider',
+        ]);
+
+        $dsn = $databaseSessionRegistry->getConnectionDsn('default');
+
+        self::assertSame(
+            'any-vendor://user2:pass2@host2:2345/db2?opt2=val2',
+            $dsn->toUrl(),
+        );
+    }
+
+    public function testNonRegressionDsn(): void
+    {
+        $databaseSessionRegistry = new StandaloneDatabaseSessionRegistry([
+            'default' => 'any-vendor://user4:pass4@host4:2345/db4?opt4=val4',
+        ]);
+
+        $dsn = $databaseSessionRegistry->getConnectionDsn('default');
+
+        self::assertSame(
+            'any-vendor://user4:pass4@host4:2345/db4?opt4=val4',
+            $dsn->toUrl(),
+        );
+    }
+
+    public function testErrorClass(): void
+    {
+        $databaseSessionRegistry = new StandaloneDatabaseSessionRegistry([
+            'default' => '\stdClass',
+        ]);
+
+        self::expectException(ConfigurationException::class);
+        self::expectExceptionMessage("'default': connection provider object must either implement MakinaCorpus\\DbToolsBundle\\Bridge\\Standalone\\ConnectionProvider or the __invoke() method.");
+        $databaseSessionRegistry->getConnectionDsn('default');
+    }
+}
+
+function connection_provider()
+{
+    return 'vendor://user2:pass2@host2:2345/db2?opt2=val2';
+}


### PR DESCRIPTION
In some case, static database URL is not enough, the user might want to dynamically create or fetch database URL (multi-tenant architecture, using environment variables, etc...).