### PR TITLE
fix: use restoreOptions instead of restoreBinary for defaultOptions

### DIFF
--- a/src/Restorer/AbstractRestorer.php
+++ b/src/Restorer/AbstractRestorer.php
@@ -35,7 +35,7 @@ abstract class AbstractRestorer implements LoggerAwareInterface
         protected readonly Configuration $config,
     ) {
         $this->binary = $config->getRestoreBinary() ?? $this->getDefaultBinary();
-        $this->defaultOptions = $config->getRestoreBinary() ?? $this->getBuiltinDefaultOptions();
+        $this->defaultOptions = $config->getRestoreOptions() ?? $this->getBuiltinDefaultOptions();
         $this->logger = new NullLogger();
         $this->output = new NullOutput();
         $this->timeout = $config->getRestoreTimeout();


### PR DESCRIPTION
Hi,

First, thank you for this bundle, it’s been really helpful.

I noticed a small issue when changing the restore options in the db_tools.yml file: the binary was being set instead.
This PR includes a quick fix that should resolve the issue.

Thanks